### PR TITLE
fix: argus.yml 스케줄 트리거 복원 + 대시보드 기본 정렬 최신순 수정

### DIFF
--- a/.github/workflows/argus.yml
+++ b/.github/workflows/argus.yml
@@ -1,11 +1,8 @@
 name: Argus CVE Monitor
  
 on:
-  # TEMP(Phase 0): 대청소 작업 중 매시간 자동 커밋이 작업 브랜치 푸시와
-  # 경쟁 상태를 일으키지 않도록 스케줄 트리거를 임시 비활성화.
-  # Phase 0 작업이 main에 병합된 후 아래 주석을 해제해 복원할 것.
-  # schedule:
-  #   - cron: '18 * * * *'
+  schedule:
+    - cron: '18 * * * *'  # 매시 18분 자동 실행
   workflow_dispatch:  # 수동 실행 가능
  
 permissions:

--- a/docs/js/cve-dashboard.js
+++ b/docs/js/cve-dashboard.js
@@ -181,8 +181,9 @@ function applyFilters() {
       case 'id': va = a.id || ''; vb = b.id || ''; break;
       default: va = a.date || ''; vb = b.date || '';
     }
-    if (va < vb) return sortDir;
-    if (va > vb) return -sortDir;
+    // sortDir: -1 = 내림차순(desc, 최신/큰 값 우선), 1 = 오름차순
+    if (va < vb) return -sortDir;
+    if (va > vb) return sortDir;
     return 0;
   });
 


### PR DESCRIPTION
- argus.yml: Phase 0에서 임시 비활성화했던 schedule(cron '18 * * * *') 복원. 안정화 검증(429/413 미발생)이 확인되어 매시간 자동 실행 재개.
- cve-dashboard.js: 정렬 비교자가 뒤집혀 있어 기본(date, sortDir=-1)이 오름차순(오래된 3월 먼저)으로 동작하던 버그 수정 → 최신순(newest first).