### PR TITLE
fix/chore: 전체 코드 재검증 — 장식 코드 3건 복구·데드 코드 정리

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,6 @@
 requests
 google-genai
 groq
-PyYAML
-yara-python
-pysigma
-suricataparser
 supabase
 pytz
 tenacity

--- a/src/collector.py
+++ b/src/collector.py
@@ -4,7 +4,7 @@ import pytz
 import os
 import re
 import json
-import time
+
 import hashlib
 from typing import List, Dict, Set, Optional
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
@@ -15,7 +15,6 @@ import enrichment_sources
 class CollectorError(Exception):
     """데이터 수집 관련 에러"""
     pass
-
 
 # ─────────────────────────────────────────────
 # 워터마크(진행 지점 북마크) — 누락 0 수집의 핵심
@@ -30,7 +29,6 @@ _STATE_PATH = os.path.join(
 )
 _BOOTSTRAP_HOURS = 24  # 상태 파일이 없을 때(최초 실행) 소급 조회 기간
 
-
 def read_watermark() -> datetime.datetime:
     """마지막 처리 시각(UTC) 반환. 없으면 now - _BOOTSTRAP_HOURS."""
     try:
@@ -42,7 +40,6 @@ def read_watermark() -> datetime.datetime:
     except (OSError, ValueError, json.JSONDecodeError) as e:
         logger.info(f"워터마크 없음/파싱 실패({e}) → 최근 {_BOOTSTRAP_HOURS}h 부트스트랩")
     return datetime.datetime.now(pytz.UTC) - datetime.timedelta(hours=_BOOTSTRAP_HOURS)
-
 
 def write_watermark(dt_utc: datetime.datetime) -> None:
     """처리 완료 지점(UTC)을 상태 파일에 기록."""
@@ -56,12 +53,6 @@ def write_watermark(dt_utc: datetime.datetime) -> None:
         logger.warning(f"워터마크 저장 실패: {e}")
 
 class Collector:
-    # 벌크 메인테넌스 커밋 감지 패턴
-    BULK_PATTERNS = re.compile(
-        r'(format|standardize|normalize|batch|bulk|automated|metadata|date.?time|migration|mass.?update|reformat)',
-        re.IGNORECASE
-    )
-
     def __init__(self):
         self.kev_set: Set[str] = set()
         self.vulncheck_kev_set: Set[str] = set()
@@ -70,12 +61,6 @@ class Collector:
             "Authorization": f"token {os.environ.get('GH_TOKEN')}",
             "Accept": "application/vnd.github.v3+json"
         }
-        # config import는 순환 참조 방지를 위해 지연
-        try:
-            from config import config
-            self.bulk_threshold = config.PERFORMANCE.get("bulk_commit_threshold", 100)
-        except Exception:
-            self.bulk_threshold = 100
     
     @retry(
         stop=stop_after_attempt(3),
@@ -171,26 +156,6 @@ class Collector:
         }
         canonical = json.dumps(meaningful, sort_keys=True, separators=(',', ':'))
         return hashlib.sha256(canonical.encode()).hexdigest()
-
-    def _is_bulk_commit(self, commit_detail: dict) -> bool:
-        """벌크 메인테넌스 커밋인지 감지.
-
-        조건: 파일 수가 threshold 이상이면 벌크로 간주.
-        커밋 메시지에 벌크 패턴이 있으면 추가 확신.
-        """
-        files = commit_detail.get('files', [])
-        file_count = len(files)
-        message = commit_detail.get('commit', {}).get('message', '')
-
-        # 파일 수만으로 벌크 판단 (threshold 이상이면 항상 벌크)
-        if file_count >= self.bulk_threshold:
-            if self.BULK_PATTERNS.search(message):
-                logger.info(f"벌크 커밋 감지: {file_count}개 파일, 메시지 패턴 매칭")
-            else:
-                logger.info(f"벌크 커밋 감지: {file_count}개 파일 (대량 수정)")
-            return True
-
-        return False
 
     def _extract_cve_id(self, filename: str) -> Optional[str]:
         """파일명에서 CVE ID 추출"""
@@ -553,10 +518,12 @@ class Collector:
             return False
     
     def enrich_from_nvd(self, cve_data: Dict) -> Dict:
-        """NVD에서 CVSS/CWE 보충 (CVEProject에 없을 때)"""
+        """NVD에서 CVSS/CWE 보충 (CVEProject에 없을 때) + CPE 수집"""
         api_key = os.environ.get("NVD_API_KEY")
         cve_id = cve_data['id']
-        
+        # 자산 매칭용 선제 조회와 위협인텔 경로의 이중 호출 방지 플래그 ('_' 접두 → DB 미저장)
+        cve_data['_nvd_enriched'] = True
+
         try:
             rate_limit_manager.check_and_wait("nvd")
             
@@ -772,8 +739,12 @@ class Collector:
         cve_id = cve_data['id']
         # VulnCheck KEV (이미 fetch한 세트에서 조회 — 메모리)
         cve_data['is_vulncheck_kev'] = cve_id in self.vulncheck_kev_set
-        # ExploitDB 공개 익스플로잇 (캐시 인덱스 조회)
-        cve_data['has_public_exploit'] = enrichment_sources.has_public_exploit(cve_id)
+        # ExploitDB 공개 익스플로잇 (캐시 인덱스 조회). PoC 원문은 재게시하지 않고
+        # 링크만 리포트에 싣는다(불변 원칙 8-②) — EDB-ID로 공식 페이지 URL 구성.
+        edb_entry = enrichment_sources.exploitdb_entry(cve_id)
+        cve_data['has_public_exploit'] = edb_entry is not None
+        if edb_entry and edb_entry[1]:
+            cve_data['_exploit_db_url'] = f"https://www.exploit-db.com/exploits/{edb_entry[1]}"
         # Metasploit 모듈 (캐시 인덱스 조회, "무기화됨" 신호, BSD-3-Clause)
         msf_modules = enrichment_sources.metasploit_modules(cve_id)
         cve_data['has_metasploit_module'] = bool(msf_modules)
@@ -794,7 +765,9 @@ class Collector:
             self.enrich_cheap_signals(cve_data)
 
         # 1. NVD CVSS/CWE 보충 → CPE로 영향자산(벤더/제품) 보강 (자산 매칭 누락 방지)
-        cve_data = self.enrich_from_nvd(cve_data)
+        #    자산 매칭 단계에서 이미 선제 조회했으면 재호출 생략
+        if not cve_data.get('_nvd_enriched'):
+            cve_data = self.enrich_from_nvd(cve_data)
         cve_data = self._augment_affected_from_cpe(cve_data)
 
         # 2. PoC 존재 여부 (nomi-sec → trickest 네트워크 검색)

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 class ConfigError(Exception):
     """설정 관련 에러"""
@@ -55,7 +55,7 @@ class ArgusConfig:
 
 
     # ==========================================
-    # [3] 성능 최적화 설정
+    # [2] 성능 최적화 설정
     # ==========================================
     PERFORMANCE = {
         # TPM이 250K로 상향되어 병렬 워커의 8K TPM 429 폭주 위험이 사라짐 → 병렬 복원.
@@ -67,7 +67,6 @@ class ArgusConfig:
         # (타임아웃으로 killed 되어도 워터마크 미저장 → 다음 실행 재수집, 누락 0.)
         "max_cves_per_run": 120,
         "max_rule_recheck": 10,  # 공식 룰 재확인 배치 크기
-        "bulk_commit_threshold": 100,  # 벌크 커밋 판단 기준 (파일 수)
         # 에스컬레이션 재평가 스윕 — 레코드(cvelistV5) 미변경이라 재수집 큐에 안 올라오는
         # '현재 저위험' CVE의 외부 피드(KEV/EPSS/ExploitDB/Metasploit) 변화로 인한 고위험 승격
         # 누락을 메운다. 후보는 최근 N일·최신순 limit건, 실제 승격분만 풀 재처리(상한).
@@ -77,7 +76,7 @@ class ArgusConfig:
     }
     
     # ==========================================
-    # [4] 필수 환경 변수 목록
+    # [3] 필수 환경 변수 목록
     # ==========================================
     REQUIRED_ENV_VARS = [
         "GH_TOKEN",

--- a/src/database.py
+++ b/src/database.py
@@ -56,29 +56,31 @@ class ArgusDB:
             logger.error(f"CVE 저장 실패 ({data.get('id')}): {e}")
             return False
     
-    def get_ai_generated_cves(self, days: int = 7) -> List[Dict]:
+    def get_rule_recheck_candidates(self) -> List[Dict]:
         """
-        공식 룰 재확인이 필요한 고위험 CVE 조회.
+        공개(공식) 룰 재확인이 필요한 고위험 CVE 조회.
 
         대상:
-        1. AI 룰만 있는 CVE (has_official_rules=False, rules_snapshot != null) — 공식 룰 교체 필요
-        2. 룰이 아예 없는 고위험 CVE (CVSS >= 7.0 or KEV) — 새로 공식 룰 나왔을 수 있음
+        1. 리포트는 됐지만 공개 룰 미확인 CVE (has_official_rules=False, rules_snapshot != null)
+           — 이후 공개 룰셋에 룰이 등록됐을 수 있음
+        2. rules_snapshot이 없는 고위험 CVE (CVSS >= 7.0) — Issue 생성 실패 등으로
+           룰 검색 기록이 없는 케이스 재확인
 
         쿨다운:
         - 성공 시: 7일 후 재확인
         - 실패 시: 1일 후 재시도 (빠른 복구)
         """
         try:
-            # Case 1: AI 룰만 있는 CVE
-            ai_response = self._execute(
+            # Case 1: 공개 룰 미확인 CVE
+            norules_response = self._execute(
                 self.client.table("cves")
                 .select("*")
                 .eq("has_official_rules", False)
                 .not_.is_("rules_snapshot", "null")
             )
 
-            # Case 2: 룰이 아예 없는 고위험 CVE (CVSS >= 7.0)
-            norule_response = self._execute(
+            # Case 2: 룰 검색 기록이 없는 고위험 CVE (CVSS >= 7.0)
+            norecord_response = self._execute(
                 self.client.table("cves")
                 .select("*")
                 .is_("rules_snapshot", "null")
@@ -86,9 +88,9 @@ class ArgusDB:
             )
 
             all_records = {}
-            for record in (ai_response.data or []):
+            for record in (norules_response.data or []):
                 all_records[record['id']] = record
-            for record in (norule_response.data or []):
+            for record in (norecord_response.data or []):
                 all_records[record['id']] = record
 
             if not all_records:
@@ -150,12 +152,12 @@ class ArgusDB:
                 -(r.get('epss_score', 0) or 0),
             ))
 
-            total = len(ai_response.data or []) + len(norule_response.data or [])
-            logger.info(f"AI 생성 룰 CVE: {total}건 중 재확인 대상: {len(eligible)}건")
+            total = len(norules_response.data or []) + len(norecord_response.data or [])
+            logger.info(f"공개 룰 미확인 CVE: {total}건 중 재확인 대상: {len(eligible)}건")
             return eligible
 
         except Exception as e:
-            logger.error(f"AI 생성 CVE 조회 실패: {e}")
+            logger.error(f"룰 재확인 후보 조회 실패: {e}")
             return []
     
     def batch_get_content_hashes(self, cve_ids: List[str]) -> Dict[str, str]:

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from datetime import datetime
 
 class ColoredFormatter(logging.Formatter):
     # ANSI 색상 코드

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,6 @@ import datetime
 import time
 import requests
 import pytz
-import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Tuple, Optional
 from google import genai
@@ -164,6 +163,20 @@ def is_target_asset(cve_data: Dict, cve_id: str) -> Tuple[bool, Optional[str]]:
             return True, f"Matched (description): {t_vendor}/{t_product}"
 
     return False, None
+
+def _needs_cpe_for_matching(cve_data: Dict) -> bool:
+    """자산 매칭에 NVD CPE 선제 조회가 필요한지 판단.
+
+    전체 감시(*/*)면 매칭이 항상 참이라 불필요. 특정 자산 감시인데 CVE의 affected에
+    유효한 벤더가 하나도 없으면(Unknown/N-A), NVD CPE 없이는 벤더 매칭이 불가능해
+    감시 대상 CVE를 놓칠 수 있다 → 이때만 True (NVD 1회 조회 비용 발생)."""
+    targets = config.get_target_assets()
+    if any(t.get('vendor') == '*' and t.get('product') == '*' for t in targets):
+        return False
+    return not any(
+        a.get('vendor', '').lower() not in ('', 'unknown', 'n/a')
+        for a in cve_data.get('affected', [])
+    )
 
 def generate_korean_summary(cve_data: Dict, retry_on_transient: bool = False) -> Tuple[str, str]:
     """CVE 제목/설명을 한국어로 번역. 실패 시 영문 원본 폴백.
@@ -474,7 +487,11 @@ def process_single_cve(cve_id: str, collector: Collector, db: ArgusDB, notifier:
             logger.debug(f"{cve_id}: PUBLISHED 상태 아님, 건너뜀")
             return {"cve_id": cve_id, "status": "handled"}
 
-        # Step 2: 자산 필터링 (affected vendor/product 우선, description 보조)
+        # Step 2: 자산 필터링 (affected vendor/product 우선, NVD CPE 보조, description 보조)
+        # 특정 자산 감시(*/* 아님) + CVE에 유효 벤더 없음이면 NVD CPE를 선제 조회해 매칭
+        # 소스를 확보한다(자산 매칭 누락 방지). 전체 감시(*/*)에서는 호출 안 함(비용 0).
+        if _needs_cpe_for_matching(raw_data):
+            collector.enrich_from_nvd(raw_data)
         is_target, match_info = is_target_asset(raw_data, cve_id)
         if not is_target:
             logger.debug(f"{cve_id}: 감시 대상 아님, 건너뜀")
@@ -508,6 +525,8 @@ def process_single_cve(cve_id: str, collector: Collector, db: ArgusDB, notifier:
             "has_public_exploit": raw_data.get('has_public_exploit', False),
             "has_metasploit_module": raw_data.get('has_metasploit_module', False),
             "metasploit_modules": raw_data.get('metasploit_modules', []),
+            # ExploitDB 링크(원문 미게시, 링크만 — 8-②). '_' 접두라 DB 저장에서 자동 제외.
+            "_exploit_db_url": raw_data.get('_exploit_db_url'),
         }
         
         # Step 4: 알림 필요성 판단
@@ -665,12 +684,11 @@ def _should_send_alert(current: Dict, last: Optional[Dict]) -> Tuple[bool, str, 
 
 def check_for_official_rules() -> None:
     """
-    공식 룰 재발견 체크.
+    공개(공식) 룰 재발견 체크.
 
-    대상:
-    1. AI 룰만 있는 CVE → 공식 룰로 교체
-    2. 룰이 아예 없는 고위험 CVE (CVSS >= 7.0, KEV) → 새로 나온 공식 룰 적용
-    3. 룰 없이 AI 생성도 실패한 CVE → 재시도
+    최초 리포트 시점에는 공개 룰셋(SigmaHQ/ET Open/Yara-Rules)에 룰이 없던 CVE도,
+    시간이 지나면 룰이 등록되는 경우가 많다. 공개 룰 미확인 상태의 고위험 CVE를
+    주기적으로 재검색해, 발견 시 기존 Issue에 댓글 + Slack 알림으로 반영한다.
 
     배치 제한: config 기반 (기본 10건)
     쿨다운: 성공 7일 / 실패 1일 (빠른 재시도)
@@ -682,7 +700,7 @@ def check_for_official_rules() -> None:
         notifier = SlackNotifier()
         rule_manager = RuleManager()
 
-        candidates = db.get_ai_generated_cves()
+        candidates = db.get_rule_recheck_candidates()
 
         if not candidates:
             logger.info("재확인 대상 없음")
@@ -718,8 +736,8 @@ def check_for_official_rules() -> None:
                     found_count += 1
                     logger.info(f"✅ {cve_id}: 공식 룰 발견!")
 
-                    # Slack 알림
-                    title_ko = record.get('last_alert_state', {}).get('title_ko', cve_id)
+                    # Slack 알림 (보존정책으로 last_alert_state가 null일 수 있음 → or 폴백)
+                    title_ko = (record.get('last_alert_state') or {}).get('title_ko', cve_id)
                     notifier.send_official_rule_update(
                         cve_id=cve_id,
                         title=title_ko,
@@ -808,28 +826,38 @@ def check_for_escalations(collector: Collector, db: ArgusDB, notifier: SlackNoti
 
         escalated: List[str] = []
         for record in candidates:
-            cve_id = record['id']
-            last = record.get('last_alert_state')
-            if not last:
+            try:
+                cve_id = record['id']
+                last = record.get('last_alert_state')
+                if not last:
+                    continue
+
+                # current = last 복사 후 외부 피드 4개 필드만 최신값으로 덮어씀.
+                # 레코드 기반 필드(cvss/cwe/affected/ssvc)는 레코드 미변경이라 last 그대로 둔다
+                # → CVSS 상향 트리거는 여기서 안 잡히고(정상: 레코드 변경 경로가 담당) 외부 피드
+                #   전이(KEV/EPSS/ExploitDB/Metasploit)만 판정한다.
+                current = dict(last)
+                # 구버전 state에 cvss/epss 키가 없을 수 있음 → 스칼라 컬럼으로 폴백 (KeyError 방지)
+                current.setdefault('cvss', record.get('cvss_score') or 0.0)
+                base_epss = last.get('epss')
+                if base_epss is None:
+                    base_epss = record.get('epss_score') or 0.0
+                current['is_kev'] = cve_id in collector.kev_set
+                current['epss'] = collector.epss_cache.get(cve_id, base_epss)
+                # ExploitDB/Metasploit 신호는 캐시 인덱스 조회 — collector 로직 재사용(네트워크 0)
+                probe = {'id': cve_id}
+                collector.enrich_cheap_signals(probe)
+                current['has_public_exploit'] = probe.get('has_public_exploit') or last.get('has_public_exploit', False)
+                current['has_metasploit_module'] = probe.get('has_metasploit_module') or last.get('has_metasploit_module', False)
+
+                should, reason, _ = _should_send_alert(current, last)
+                if should:
+                    logger.info(f"🔁 {cve_id}: 외부 피드 에스컬레이션 감지 ({reason})")
+                    escalated.append(cve_id)
+            except Exception as e:
+                # 한 레코드의 이상 데이터가 스윕 전체를 중단시키지 않게 격리
+                logger.warning(f"{record.get('id', '?')} 에스컬레이션 재평가 실패: {e}")
                 continue
-
-            # current = last 복사 후 외부 피드 4개 필드만 최신값으로 덮어씀.
-            # 레코드 기반 필드(cvss/cwe/affected/ssvc)는 레코드 미변경이라 last 그대로 둔다
-            # → CVSS 상향 트리거는 여기서 안 잡히고(정상: 레코드 변경 경로가 담당) 외부 피드
-            #   전이(KEV/EPSS/ExploitDB/Metasploit)만 판정한다.
-            current = dict(last)
-            current['is_kev'] = cve_id in collector.kev_set
-            current['epss'] = collector.epss_cache.get(cve_id, last.get('epss') or 0.0)
-            # ExploitDB/Metasploit 신호는 캐시 인덱스 조회 — collector 로직 재사용(네트워크 0)
-            probe = {'id': cve_id}
-            collector.enrich_cheap_signals(probe)
-            current['has_public_exploit'] = probe.get('has_public_exploit') or last.get('has_public_exploit', False)
-            current['has_metasploit_module'] = probe.get('has_metasploit_module') or last.get('has_metasploit_module', False)
-
-            should, reason, _ = _should_send_alert(current, last)
-            if should:
-                logger.info(f"🔁 {cve_id}: 외부 피드 에스컬레이션 감지 ({reason})")
-                escalated.append(cve_id)
 
         if not escalated:
             logger.info(f"에스컬레이션 후보 {len(candidates)}건 재평가 — 승격 없음")

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -45,7 +45,8 @@ class RateLimitManager:
                 window_seconds=3600,
                 min_interval=0.5
             ),
-            # Groq Free Tier: RPM 30 / TPM 8000 / TPD 200K
+            # Groq Free Tier: RPM 30 (분당 요청). 일일 한도는 모델별로 상이 —
+            # compound 계열 RPD 250, gpt-oss/qwen TPD 200K → 모델별 카운터로 별도 추적.
             "groq": RateLimitInfo(
                 limit=30,
                 window_seconds=60,

--- a/src/rule_manager.py
+++ b/src/rule_manager.py
@@ -1,6 +1,5 @@
 import os
 import io
-import json
 import re
 import tarfile
 import threading
@@ -9,25 +8,8 @@ from typing import Dict, Optional, List
 from logger import logger
 from rate_limiter import rate_limit_manager
 
-# pySigma: Sigma 룰 실제 파싱 검증 (오프라인, 무료 pip) — 미설치 시 구조 검사만 수행
-try:
-    from sigma.collection import SigmaCollection
-    _PYSIGMA_AVAILABLE = True
-except ImportError:
-    SigmaCollection = None
-    _PYSIGMA_AVAILABLE = False
-
-# suricataparser: Snort/Suricata 룰 실제 파싱 검증 (순수 Python) — 미설치 시 정규식 폴백
-try:
-    import suricataparser
-    _SURICATAPARSER_AVAILABLE = True
-except ImportError:
-    suricataparser = None
-    _SURICATAPARSER_AVAILABLE = False
-
-class RuleManagerError(Exception):
-    pass
-
+# AI 룰 생성 제거 이후 RuleManager는 '공개 룰 검색기'다. 공개 룰(SigmaHQ/ET Open/
+# Yara-Rules)은 출처 자체가 검증 주체이므로 별도 파서 검증(pySigma 등)을 하지 않는다.
 
 # 디스크 캐시(24h TTL)는 enrichment_sources와 공유한다.
 # (매시간 실행에서 재다운로드 방지 + collector와 동일 캐시 파일 재사용)


### PR DESCRIPTION
동작 안 하던 '장식' 코드 복구:
- ExploitDB 링크(_exploit_db_url): Issue가 읽기만 하고 설정하는 곳이 없어 링크가 절대 표시되지 않던 문제 → enrich_cheap_signals에서 EDB-ID로 URL 구성(원문 미게시, 링크만 — 불변 원칙 8-②), current_state로 전달('_' 접두라 DB 미저장)
- is_target_asset의 NVD CPE 2차 매칭: 자산 필터 시점에 nvd_cpe가 항상 빈값이라 도달 불가였음 → 특정 자산 감시 + 유효 벤더 없음일 때만 NVD 선제 조회 (_needs_cpe_for_matching; 전체 감시 */*에서는 비용 0, 이중 호출은 _nvd_enriched로 방지)
- 에스컬레이션 스윕 견고성: 구버전 last_alert_state에 cvss/epss 키가 없으면 KeyError로 스윕 전체가 중단될 수 있던 문제 → 스칼라 컬럼 폴백 + 레코드별 예외 격리

데드 코드/의존성 정리:
- collector: _is_bulk_commit/BULK_PATTERNS/bulk_threshold 제거 (content_hash 전수 dedup으로 대체된 잔재, 호출자 없음) + config bulk_commit_threshold 키 제거
- rule_manager: pySigma/suricataparser 미사용 import 제거 (AI 룰 검증 폐지로 불용), 미사용 RuleManagerError·json 제거
- requirements.txt: PyYAML/yara-python/pysigma/suricataparser 제거 (미사용 의존성)
- database: get_ai_generated_cves → get_rule_recheck_candidates 개명 (미사용 days 파라미터 제거, 'AI 생성 룰' 명칭·독스트링·로그를 실제 동작에 맞게 교정)
- check_for_official_rules: stale 독스트링 교정 + last_alert_state null(보존정책) 크래시 방지
- main/collector/config/logger 미사용 import 제거, config 섹션 번호 재정렬, rate_limiter groq 한도 주석 현행화


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd