### PR TITLE
fix: 소프트 데드라인로 타임아웃 킬 방지 + advisory 한도 현실화

### DIFF
--- a/.github/workflows/argus.yml
+++ b/.github/workflows/argus.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   argus-run:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 파이프라인은 soft_deadline_minutes(38분)에 스스로 마무리·워터마크 저장 후 종료한다.
+    # 이 값은 그게 실패했을 때의 최후 안전장치 (셋업+export+commit 여유 포함).
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,13 +54,17 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: python src/main.py
  
+      # if: always() — 파이프라인이 중간에 실패해도, 이미 정상 저장된 워터마크/대시보드
+      # 데이터는 커밋한다 (워터마크 파일은 _main 말미에만 쓰이므로 잘못 전진할 일 없음).
       - name: Export dashboard data
+        if: always()
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: python src/export_dashboard_data.py
- 
+
       - name: Commit and push dashboard data
+        if: always()
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/src/collector.py
+++ b/src/collector.py
@@ -4,7 +4,7 @@ import pytz
 import os
 import re
 import json
-
+import time
 import hashlib
 from typing import List, Dict, Set, Optional
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
@@ -195,13 +195,17 @@ class Collector:
         wait=wait_exponential(multiplier=1, min=2, max=10)
     )
     def fetch_cves_since(self, since_dt: datetime.datetime, db=None, max_commit_pages: int = 300,
-                         until_dt: Optional[datetime.datetime] = None) -> List[dict]:
+                         until_dt: Optional[datetime.datetime] = None,
+                         deadline_ts: Optional[float] = None) -> List[dict]:
         """워터마크(since_dt) 이후(선택적으로 until_dt까지) 커밋에서 변경된 CVE를 빠짐없이 수집.
 
         고정 시간창(누락 위험) 대신 '마지막 처리 지점' 이후 전부를 조회한다.
         스케줄이 아무리 불규칙해도(수시간·수일 지연) 빈틈이 생기지 않는다.
         until_dt는 초장기 공백 캐치업 시 한 실행의 조회량을 상한하기 위한 것 —
         창 밖(이후) 커밋은 다음 실행이 전진된 워터마크에서 이어서 수집한다.
+        deadline_ts(time.time() 기준)는 소프트 데드라인 — 커밋 상세 순회가 오름차순이라
+        중간에 멈춰도 안전하다: 워터마크는 '본 것'의 최대 시각까지만 전진하므로
+        못 본 이후 커밋은 다음 실행이 이어서 수집한다(누락 0 유지).
 
         Returns:
             List[dict]: [{"cve_id", "commit_ts"(datetime), "is_new"(bool)}], commit_ts 오름차순.
@@ -250,6 +254,10 @@ class Collector:
         # (수백~수천 파일)에서 301번째 이후 CVE가 조용히 누락되지 않게 페이지네이션한다.
         cve_ts: Dict[str, datetime.datetime] = {}
         for commit in commits:
+            # 소프트 데드라인: 오름차순 순회라 여기서 멈춰도 안전 (본 것까지만 워터마크 전진)
+            if deadline_ts is not None and time.time() > deadline_ts:
+                logger.warning("⏰ 수집 시간 예산 도달 — 지금까지 상세 조회한 커밋까지만 처리 (이후는 다음 실행)")
+                break
             try:
                 ts = datetime.datetime.fromisoformat(self._commit_ts(commit).replace("Z", "+00:00"))
             except (ValueError, AttributeError):
@@ -287,6 +295,11 @@ class Collector:
         for cid, ts in cve_ts.items():
             old_hash = existing.get(cid)
             if old_hash is None:
+                result.append({"cve_id": cid, "commit_ts": ts, "is_new": True})
+                continue
+            # 데드라인 도달 시 해시 사전검사(원문 fetch) 생략 — 보수적으로 처리 대상 취급
+            # (중복 처리 가능성은 실행당 상한이 흡수, 누락 방지가 우선)
+            if deadline_ts is not None and time.time() > deadline_ts:
                 result.append({"cve_id": cid, "commit_ts": ts, "is_new": True})
                 continue
             raw_json = self._fetch_raw_cve_json(cid)

--- a/src/config.py
+++ b/src/config.py
@@ -64,11 +64,15 @@ class ArgusConfig:
         "max_workers": 4,
         "rule_check_interval_days": 7,  # 공식 룰 재확인 주기
         # 실행당 처리 상한. 번역이 배치(translation_batch_size건/호출)라 250건이어도
-        # Gemma 호출은 ~25회(=100초)뿐 — 30분 타임아웃 내 완주하며 백로그(수백~수천)를
+        # Gemma 호출은 ~25회(=100초)뿐 — 시간 예산 내 완주하며 백로그(수백~수천)를
         # 신속 해소한다(일 처리능력 250×24=6,000건 » 유입). RPD도 25×24=600콜/일로 여유.
-        # (타임아웃으로 killed 되어도 워터마크 미저장 → 다음 실행 재수집, 누락 0.)
         "max_cves_per_run": 250,
         "translation_batch_size": 10,  # 일괄 번역: Gemma 호출당 CVE 수
+        # 소프트 데드라인 — GitHub Actions timeout(45분)에 killed 되기 전에 스스로 마무리한다.
+        # 초과 시: 잔여 CVE를 failed로 남기고(워터마크가 붙잡아 다음 실행 재처리) 워터마크
+        # 저장·요약까지 정상 종료. killed 되면 워터마크를 못 써 다음 실행이 수집을 통째로
+        # 반복하므로, '항상 깨끗하게 끝내고 전진'이 핵심. (잡 셋업/export/commit 여유 ~7분)
+        "soft_deadline_minutes": 38,
         "max_rule_recheck": 10,  # 공식 룰 재확인 배치 크기
         # 에스컬레이션 재평가 스윕 — 레코드(cvelistV5) 미변경이라 재수집 큐에 안 올라오는
         # '현재 저위험' CVE의 외부 피드(KEV/EPSS/ExploitDB/Metasploit) 변화로 인한 고위험 승격

--- a/src/main.py
+++ b/src/main.py
@@ -1067,17 +1067,26 @@ def _main():
     # 실행해 승격 재알림이 신규 저위험 백로그보다 우선 Groq 예산을 확보하고 타임아웃 전에 완주하게 한다.
     check_for_escalations(collector, db, notifier)
 
+    # 소프트 데드라인 — Actions timeout(45분)에 killed 되면 워터마크를 못 써 다음 실행이
+    # 수집을 통째로 반복한다. 그 전에 스스로 잔여 작업을 failed로 남기고(워터마크가 붙잡음)
+    # 워터마크 저장·요약까지 '항상 깨끗하게' 끝내는 것이 전진의 핵심.
+    soft_deadline_ts = start_time + config.PERFORMANCE.get("soft_deadline_minutes", 38) * 60
+
+    def _over_deadline() -> bool:
+        return time.time() > soft_deadline_ts
+
     run_start_utc = datetime.datetime.now(datetime.timezone.utc)
     watermark = read_watermark()
     # 경계 커밋을 놓치지 않도록 소량 겹침(overlap) — 중복은 DB dedup이 흡수
     since_dt = watermark - datetime.timedelta(minutes=5)
     # 초장기 공백(수일+) 캐치업 상한: 한 실행의 조회 창을 최대 12시간으로 제한.
-    # 무제한 조회는 커밋 상세 호출 폭증 → 30분 타임아웃 → 워터마크 미저장 → 같은 작업
+    # 무제한 조회는 커밋 상세 호출 폭증 → 타임아웃 → 워터마크 미저장 → 같은 작업
     # 반복(진행 불가)으로 이어질 수 있다. 창 밖 커밋은 다음 실행이 전진된 워터마크에서
     # 이어서 수집하므로 누락은 없다 (실행당 12h씩 따라잡음).
     catchup_horizon = watermark + datetime.timedelta(hours=12)
     until_dt = catchup_horizon if catchup_horizon < run_start_utc else None
-    fetched = collector.fetch_cves_since(since_dt, db=db, until_dt=until_dt)
+    fetched = collector.fetch_cves_since(since_dt, db=db, until_dt=until_dt,
+                                         deadline_ts=soft_deadline_ts)
 
     if not fetched:
         # 창 내 신규 커밋 없음 → 창 끝까지만 전진 (창 이후 커밋은 다음 실행이 수집)
@@ -1112,11 +1121,15 @@ def _main():
     batch_size = config.PERFORMANCE.get("translation_batch_size", 10)
     logger.info(f"처리 시작 (워커: {max_workers}명, 번역 배치 {batch_size}건/호출)")
 
-    # Phase A: 수집·분류 (병렬)
+    # Phase A: 수집·분류 (병렬) — 데드라인 도달 시 잔여 취소(미기록 → 아래 안전망이 failed 처리)
     prepared = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {executor.submit(prepare_single_cve, cid, collector, db): cid for cid in target_cve_ids}
         for future in as_completed(futures):
+            if _over_deadline():
+                executor.shutdown(wait=False, cancel_futures=True)
+                logger.warning("⏰ 시간 예산 도달 — Phase A 잔여 취소 (다음 실행에서 재처리)")
+                break
             cid = futures[future]
             try:
                 prep = future.result() or {}
@@ -1129,27 +1142,43 @@ def _main():
             else:
                 status_by_id[cid] = prep.get("status", "failed")
 
-    # Phase B: 일괄 번역 (Gemma 호출 = ceil(n/배치))
-    tr_items = [{"id": p["cve_id"], "title": p["current_state"]["title"],
-                 "description": p["current_state"]["description"]} for p in prepared]
-    high_risk_ids = {p["cve_id"] for p in prepared if p["should_alert"]}
-    translations = generate_korean_summaries_batch(tr_items, high_risk_ids)
+    if _over_deadline():
+        # 번역/완성 없이 종료 — prepared 전부 미완료(failed) 처리해 다음 실행에서 온전히 재처리
+        logger.warning(f"⏰ 시간 예산 도달 — 준비된 {len(prepared)}건 포함 잔여분 다음 실행으로")
+        prepared = []
+    else:
+        # Phase B: 일괄 번역 (Gemma 호출 = ceil(n/배치))
+        tr_items = [{"id": p["cve_id"], "title": p["current_state"]["title"],
+                     "description": p["current_state"]["description"]} for p in prepared]
+        high_risk_ids = {p["cve_id"] for p in prepared if p["should_alert"]}
+        translations = generate_korean_summaries_batch(tr_items, high_risk_ids)
 
-    # Phase C: 완성 — Issue/Slack/저장 (병렬)
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(finalize_single_cve, p, translations.get(p["cve_id"]),
-                            collector, db, notifier): p["cve_id"]
-            for p in prepared
-        }
-        for future in as_completed(futures):
-            cid = futures[future]
-            try:
-                result = future.result() or {}
-                status_by_id[cid] = result.get("status", "failed")
-            except Exception as e:
-                logger.error(f"{cid} 처리 중 예외 발생: {e}")
-                status_by_id[cid] = "failed"
+        # Phase C: 완성 — Issue/Slack/저장 (병렬).
+        # 고위험(알림 대상)을 먼저 제출해 데드라인이 닥쳐도 핵심 알림부터 완료되게 한다.
+        prepared.sort(key=lambda p: (0 if p["should_alert"] else 1))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(finalize_single_cve, p, translations.get(p["cve_id"]),
+                                collector, db, notifier): p["cve_id"]
+                for p in prepared
+            }
+            for future in as_completed(futures):
+                if _over_deadline():
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    logger.warning("⏰ 시간 예산 도달 — Phase C 잔여 취소 (다음 실행에서 재처리)")
+                    break
+                cid = futures[future]
+                try:
+                    result = future.result() or {}
+                    status_by_id[cid] = result.get("status", "failed")
+                except Exception as e:
+                    logger.error(f"{cid} 처리 중 예외 발생: {e}")
+                    status_by_id[cid] = "failed"
+
+    # 안전망: 상태가 기록되지 않은 처리 대상(취소·미완료)은 전부 failed —
+    # 워터마크 계산이 이들을 '처리됨'으로 오인해 건너뛰면 영구 누락이므로 반드시 필요.
+    for c in to_process:
+        status_by_id.setdefault(c['cve_id'], "failed")
 
     # Step 8: 워터마크 전진 계산 (누락 0의 핵심)
     # 미처리(unhandled) = 실패한 처리분 + 상한으로 이월된 분. 이들의 최소 커밋시각 앞까지만 전진.

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -87,9 +87,11 @@ class RateLimitManager:
                 window_seconds=60,
                 min_interval=1.5
             ),
-            # GitHub Advisory API: 일반 GitHub API 한도 공유
+            # GitHub Advisory API: REST 코어 한도(토큰당 5,000/h)를 github 버킷과 공유.
+            # 실측 사용량(수집+enrich+PoC ≈ 1,200/h)을 감안해 900/h까지 허용 — 100/h는
+            # 지나치게 보수적이라 고위험 100건+ 실행에서 매번 소진 로그를 냈다.
             "github_advisory": RateLimitInfo(
-                limit=100,
+                limit=900,
                 window_seconds=3600,
                 min_interval=0.5
             ),
@@ -101,6 +103,8 @@ class RateLimitManager:
         }
         
         self._lock = threading.Lock()
+        # 소진-SKIP 경고 중복 억제 (같은 윈도우 내 반복 경고는 debug로 강등)
+        self._skip_warned_at: Dict[str, datetime] = {}
 
         self.stats = {
             "total_calls": 0,
@@ -230,10 +234,16 @@ class RateLimitManager:
                 if wait_time <= 0:
                     wait_time = info.window_seconds
                 if max_wait is not None and wait_time > max_wait:
-                    logger.warning(
-                        f"⏭️ {api_name} 한도 소진 ({info.used}/{info.limit}) — "
-                        f"{wait_time:.0f}초 대기 대신 SKIP (다음 윈도우에서 재개)"
-                    )
+                    # 같은 윈도우 내 반복 SKIP은 debug로 — 경고 스팸 방지 (첫 회만 warning)
+                    last_warn = self._skip_warned_at.get(api_name)
+                    if last_warn is None or last_warn < info.reset_at - timedelta(seconds=info.window_seconds):
+                        logger.warning(
+                            f"⏭️ {api_name} 한도 소진 ({info.used}/{info.limit}) — "
+                            f"{wait_time:.0f}초 대기 대신 SKIP (이 윈도우의 후속 SKIP 로그는 생략)"
+                        )
+                        self._skip_warned_at[api_name] = now
+                    else:
+                        logger.debug(f"{api_name} 한도 소진 SKIP")
                     return False
                 exhausted_wait = wait_time
                 logger.warning(


### PR DESCRIPTION
문제 1: 실행이 30분 타임아웃에 killed → 워터마크 미저장 → 다음 실행이 수집
(커밋 상세 조회 수 분)을 통째로 반복. 만성 초과 시 전진 정지 위험.
(처리분 자체는 content_hash 저장으로 다음 실행 dedup — 데이터 유실은 없음)

문제 2: github_advisory 자체 버킷 100/h가 지나치게 보수적 — 실제 REST 코어 한도는 토큰당 5,000/h. 고위험 100건+ 실행마다 소진 SKIP 로그 반복.

해결:
- 소프트 데드라인(38분, config): killed 되기 전에 스스로 마무리 — · 수집: 커밋 상세 순회(오름차순) 중단 → 워터마크는 '본 것'까지만 전진(누락 0) · 해시 사전검사: 초과 시 원문 fetch 생략, 보수적으로 처리 대상 취급 · Phase A/C: 잔여 future 취소, Phase C는 고위험 먼저 제출(핵심 알림 우선 완료) · 안전망: 상태 미기록 CVE 전부 failed 처리 — 워터마크가 '처리됨'으로 오인해 건너뛰는 영구 누락 차단 · 이후 워터마크 저장·Slack 요약·rate 요약까지 항상 정상 종료
- argus.yml: timeout 30→45분(최후 안전장치), export/commit 스텝 if:always() — 파이프라인이 중간 실패해도 정상 저장된 워터마크는 커밋
- github_advisory 버킷 100→900/h + 소진 SKIP 경고 윈도우당 1회로 스팸 제거

검증: 수집 데드라인 중단 시 '본 것까지' 수집·워터마크 상한 확인, 미기록→failed 안전망, advisory 900 + 경고 1회, 기존 5개 스위트 회귀 전부 통과.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd