### PR TITLE
feat: EPSS 절대 임계치(≥0.1)를 고위험 정의에 추가

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -830,12 +830,15 @@ def process_single_cve(cve_id: str, collector: Collector, db: ArgusDB, notifier:
     return finalize_single_cve(prep, translation, collector, db, notifier)
 
 def _should_send_alert(current: Dict, last: Optional[Dict]) -> Tuple[bool, str, bool]:
-    # 무기화·실제 악용 신호는 CVSS와 무관하게 고위험으로 승격 (P5)
+    # 무기화·실제 악용 신호는 CVSS와 무관하게 고위험으로 승격 (P5).
+    # EPSS ≥ 0.1(전체 상위 ~5%)은 절대 임계치 — 악용 확률이 이미 높은 CVE는 CVSS가
+    # 낮아도 고위험 취급해 비자산(*/*)에서도 수신되게 한다(기준선 없이 판정 가능).
     is_high_risk = (
         current['cvss'] >= 7.0
         or current['is_kev']
         or current.get('has_metasploit_module')
         or current.get('ssvc_exploitation') == 'active'
+        or current.get('epss', 0.0) >= 0.1
     )
 
     # 신규 CVE: 고위험만 알림(Slack/Issue). 저위험 신규는 대시보드 추적만 하고


### PR DESCRIPTION
'EPSS 급증' 트리거는 전이 기반이라 기준선(추적 상태)이 필요해, 비자산 미추적
CVE는 EPSS가 높아도 수신되지 않았다. EPSS ≥ 0.1(전체 CVE 상위 ~5%)은 기준선 없이 판정 가능한 절대 신호이므로 고위험 정의에 추가:

- 비자산(*/*) 신규/재처리 CVE도 EPSS ≥ 0.1이면 풀 알림(Issue+Slack) 수신
- 추적 중 CVE의 EPSS 급증 재알림(스윕)은 기존 그대로
- 신규 CVE는 대부분 EPSS가 낮게 시작하므로 알림 증가는 소폭

검증: EPSS 0.15 비자산 신규 → 고위험 풀 알림 경로 / 0.05 → 마커 유지. 7개 스위트 회귀 전부 통과.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd