### PR TITLE
feat(dashboard): 위협 중심 UI 전면 재설계

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,599 +1,307 @@
-/* ===== Argus Dashboard - Dark Theme ===== */
+/* ==========================================================================
+   Argus CVE Dashboard — 위협 중심 재설계
+   다크 우선. severity=status 색(라벨 항상 동반), 신호=구분 hue.
+   ========================================================================== */
 
 :root {
-  --bg-primary: #0d1117;
-  --bg-secondary: #161b22;
-  --bg-tertiary: #21262d;
-  --border: #30363d;
-  --text-primary: #e6edf3;
-  --text-secondary: #8b949e;
-  --text-muted: #6e7681;
-  --critical: #FF4444;
-  --high: #FF8800;
-  --medium: #FFCC00;
-  --low: #44BB44;
-  --info: #58a6ff;
-  --accent: #1f6feb;
+  --bg: #0b0f16;
+  --bg-grad: radial-gradient(1200px 600px at 80% -10%, #12233b 0%, transparent 55%),
+             radial-gradient(900px 500px at 0% 0%, #1a1230 0%, transparent 50%),
+             #0b0f16;
+  --surface: #11161f;
+  --surface-2: #161c27;
+  --surface-3: #1b222e;
+  --border: #232b39;
+  --border-strong: #303a4c;
+
+  --text: #e8eef6;
+  --text-muted: #8b97a8;
+  --text-faint: #5c6675;
+
+  --accent: #58a6ff;
+  --accent-dim: #1f3a5f;
+
+  --sev-critical: #ff5c57;
+  --sev-high: #ff9838;
+  --sev-medium: #ffd43b;
+  --sev-low: #3fb950;
+  --sev-none: #7d8590;
+
+  --sig-kev: #ff5c57;
+  --sig-msf: #c084fc;
+  --sig-edb: #f0883e;
+  --sig-poc: #22d3ee;
+
+  --radius: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.28);
+  --shadow-lg: 0 12px 40px rgba(0,0,0,.5);
+  --font: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+  --mono: ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, Consolas, monospace;
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f4f6fa;
+    --bg-grad: radial-gradient(1200px 600px at 80% -10%, #dbe9ff 0%, transparent 55%), #f4f6fa;
+    --surface: #ffffff;
+    --surface-2: #f7f9fc;
+    --surface-3: #eef2f8;
+    --border: #e2e8f2;
+    --border-strong: #cdd6e4;
+    --text: #131824;
+    --text-muted: #5a6675;
+    --text-faint: #8792a3;
+    --accent: #1f6feb;
+    --accent-dim: #cfe0fb;
+    --shadow: 0 1px 2px rgba(16,24,40,.06), 0 8px 24px rgba(16,24,40,.08);
+    --shadow-lg: 0 12px 40px rgba(16,24,40,.16);
+  }
+}
 
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  line-height: 1.6;
+  font-family: var(--font);
+  background: var(--bg-grad); background-attachment: fixed;
+  color: var(--text); line-height: 1.5; -webkit-font-smoothing: antialiased; min-height: 100vh;
 }
+.container { max-width: 1320px; margin: 0 auto; padding: 0 24px; }
 
-/* ===== Layout ===== */
-.container { max-width: 1400px; margin: 0 auto; padding: 0 24px; }
-
-/* ===== Header ===== */
+/* ---------- Header ---------- */
 .header {
-  background: var(--bg-secondary);
+  position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
   border-bottom: 1px solid var(--border);
-  padding: 16px 0;
-  position: sticky;
-  top: 0;
-  z-index: 100;
 }
-
-.header-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.header-inner { display: flex; align-items: center; gap: 16px; height: 62px; }
+.logo { display: flex; align-items: center; gap: 11px; text-decoration: none; color: var(--text); font-weight: 800; font-size: 18px; letter-spacing: -.02em; }
+.logo-badge {
+  width: 36px; height: 36px; border-radius: 10px; display: grid; place-items: center; font-size: 19px;
+  background: linear-gradient(135deg, #1f6feb, #7c3aed); box-shadow: 0 2px 12px rgba(31,111,235,.4);
 }
-
-.logo {
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--text-primary);
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.logo small { display: block; font-size: 11px; font-weight: 500; color: var(--text-muted); letter-spacing: 0; }
+.header-spacer { flex: 1; }
+.header-meta { display: flex; align-items: center; gap: 14px; }
+.live-dot {
+  display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-muted);
+  padding: 5px 11px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface);
 }
-
-.logo-icon { font-size: 24px; }
-
-.nav { display: flex; gap: 4px; }
-
-.nav a {
-  color: var(--text-secondary);
-  text-decoration: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.2s;
+.live-dot::before {
+  content: ''; width: 7px; height: 7px; border-radius: 50%; background: var(--sev-low);
+  box-shadow: 0 0 0 0 rgba(63,185,80,.6); animation: pulse 2s infinite;
 }
-
-.nav a:hover, .nav a.active {
-  color: var(--text-primary);
-  background: var(--bg-tertiary);
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(63,185,80,.5); }
+  70% { box-shadow: 0 0 0 6px rgba(63,185,80,0); }
+  100% { box-shadow: 0 0 0 0 rgba(63,185,80,0); }
 }
+.updated-at { font-size: 12px; color: var(--text-faint); }
 
-.updated-at {
-  font-size: 12px;
-  color: var(--text-muted);
+main { padding: 28px 0 64px; }
+
+/* ---------- KPI strip ---------- */
+.kpi-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 14px; margin-bottom: 22px; }
+.kpi {
+  position: relative; overflow: hidden; background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 16px 18px; box-shadow: var(--shadow);
+  transition: transform .15s ease, border-color .15s ease;
 }
+.kpi:hover { transform: translateY(-2px); border-color: var(--border-strong); }
+.kpi::after { content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--accent); }
+.kpi.is-critical::after { background: var(--sev-critical); }
+.kpi.is-kev::after { background: var(--sig-kev); }
+.kpi.is-weapon::after { background: var(--sig-msf); }
+.kpi .kpi-label { font-size: 12px; color: var(--text-muted); font-weight: 600; display: flex; align-items: center; gap: 6px; }
+.kpi .kpi-value { font-size: 30px; font-weight: 800; letter-spacing: -.03em; margin-top: 6px; font-variant-numeric: tabular-nums; }
+.kpi .kpi-sub { font-size: 11px; color: var(--text-faint); margin-top: 2px; }
+.kpi-value.c-critical { color: var(--sev-critical); }
+.kpi-value.c-kev { color: var(--sig-kev); }
+.kpi-value.c-weapon { color: var(--sig-msf); }
 
-/* ===== Stat Cards ===== */
-.stat-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-  margin: 24px 0;
-}
+/* ---------- Panels ---------- */
+.panels { display: grid; grid-template-columns: 1.7fr 1fr; gap: 16px; margin-bottom: 22px; }
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px 20px; box-shadow: var(--shadow); }
+.panel h3 { font-size: 13px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+.panel h3.mt { margin-top: 18px; }
+.chart-container { height: 200px; position: relative; }
 
-.stat-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 20px;
-}
+.dist-row { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; font-size: 12px; }
+.dist-row:last-child { margin-bottom: 0; }
+.dist-name { width: 84px; color: var(--text-muted); display: flex; align-items: center; gap: 6px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dist-track { flex: 1; height: 8px; background: var(--surface-3); border-radius: 999px; overflow: hidden; }
+.dist-fill { height: 100%; border-radius: 999px; transition: width .5s cubic-bezier(.2,.8,.2,1); }
+.dist-count { width: 40px; text-align: right; color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+.dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
 
-.stat-card .label {
-  font-size: 12px;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 4px;
-}
-
-.stat-card .value {
-  font-size: 32px;
-  font-weight: 700;
-}
-
-.stat-card .value.critical { color: var(--critical); }
-.stat-card .value.high { color: var(--high); }
-.stat-card .value.kev { color: var(--critical); }
-.stat-card .value.info { color: var(--info); }
-
-/* ===== Chart Section ===== */
-.chart-section {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 20px;
-  margin-bottom: 24px;
-}
-
-.chart-section h3 {
-  font-size: 14px;
-  color: var(--text-secondary);
-  margin-bottom: 16px;
-}
-
-.chart-container {
-  position: relative;
-  height: 200px;
-}
-
-/* ===== Filter Bar ===== */
+/* ---------- Filter bar ---------- */
 .filter-bar {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  align-items: center;
-  margin-bottom: 20px;
-  padding: 16px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  display: flex; flex-wrap: wrap; gap: 10px; align-items: center; background: var(--surface);
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 14px; margin-bottom: 16px; box-shadow: var(--shadow);
 }
-
+.search-wrap { position: relative; flex: 1 1 280px; min-width: 220px; }
+.search-wrap svg { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--text-faint); pointer-events: none; }
 .search-input {
-  flex: 1;
-  min-width: 200px;
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 14px;
-  outline: none;
+  width: 100%; padding: 10px 12px 10px 36px; background: var(--surface-2); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); color: var(--text); font-size: 14px; font-family: inherit; transition: border-color .15s, box-shadow .15s;
 }
+.search-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
+.search-input::placeholder { color: var(--text-faint); }
+.filter-select { padding: 9px 12px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text); font-size: 13px; font-family: inherit; cursor: pointer; }
+.filter-select:focus { outline: none; border-color: var(--accent); }
 
-.search-input:focus { border-color: var(--accent); }
-.search-input::placeholder { color: var(--text-muted); }
+.seg { display: inline-flex; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 3px; gap: 2px; }
+.seg-btn { padding: 6px 11px; border: none; background: transparent; color: var(--text-muted); font-size: 12px; font-weight: 600; font-family: inherit; cursor: pointer; border-radius: 6px; display: inline-flex; align-items: center; gap: 6px; transition: all .12s; }
+.seg-btn .dot { width: 7px; height: 7px; }
+.seg-btn:hover { color: var(--text); }
+.seg-btn.active { background: var(--surface-3); color: var(--text); box-shadow: inset 0 0 0 1px var(--border-strong); }
+.seg-btn.active.sev-c-critical { color: var(--sev-critical); }
+.seg-btn.active.sev-c-high { color: var(--sev-high); }
+.seg-btn.active.sev-c-medium { color: var(--sev-medium); }
+.seg-btn.active.sev-c-low { color: var(--sev-low); }
 
-.filter-select {
-  padding: 8px 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 14px;
-  cursor: pointer;
-  outline: none;
-}
+.signal-toggle { padding: 7px 12px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-muted); font-size: 12px; font-weight: 600; font-family: inherit; border-radius: 999px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; transition: all .12s; }
+.signal-toggle:hover { border-color: var(--border-strong); color: var(--text); }
+.signal-toggle.active { background: color-mix(in srgb, var(--sig-kev) 16%, var(--surface)); border-color: var(--sig-kev); color: var(--sig-kev); }
+.signal-toggle.active[data-signal="weaponized"] { background: color-mix(in srgb, var(--sig-msf) 16%, var(--surface)); border-color: var(--sig-msf); color: var(--sig-msf); }
+.signal-toggle.active[data-signal="poc"] { background: color-mix(in srgb, var(--sig-poc) 16%, var(--surface)); border-color: var(--sig-poc); color: var(--sig-poc); }
 
-.severity-filters { display: flex; gap: 4px; }
+.filter-spacer { flex: 1; }
+.export-group { display: inline-flex; gap: 6px; }
+.export-btn { padding: 8px 12px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text-muted); font-size: 12px; font-weight: 600; font-family: inherit; cursor: pointer; transition: all .12s; }
+.export-btn:hover { border-color: var(--border-strong); color: var(--text); }
+.export-btn.export-highrisk { color: var(--sev-high); border-color: color-mix(in srgb, var(--sev-high) 40%, var(--border)); }
+.export-btn.export-highrisk:hover { background: color-mix(in srgb, var(--sev-high) 12%, var(--surface)); }
 
-.severity-btn {
-  padding: 6px 12px;
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.severity-btn.active { color: #fff; }
-.severity-btn.active[data-severity="Critical"] { background: var(--critical); border-color: var(--critical); }
-.severity-btn.active[data-severity="High"] { background: var(--high); border-color: var(--high); }
-.severity-btn.active[data-severity="Medium"] { background: #b38f00; border-color: var(--medium); }
-.severity-btn.active[data-severity="Low"] { background: var(--low); border-color: var(--low); }
-
-/* ===== Table ===== */
-.table-wrapper {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
+/* ---------- Table ---------- */
+.table-wrap { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; box-shadow: var(--shadow); }
+.table-scroll { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; min-width: 820px; }
 thead th {
-  background: var(--bg-tertiary);
-  padding: 12px 16px;
-  text-align: left;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  border-bottom: 1px solid var(--border);
-  cursor: pointer;
-  user-select: none;
+  text-align: left; padding: 13px 14px; font-size: 11px; font-weight: 700; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: .04em; background: var(--surface-2); border-bottom: 1px solid var(--border);
+  position: sticky; top: 62px; z-index: 5; white-space: nowrap;
 }
+thead th.sortable { cursor: pointer; user-select: none; }
+thead th.sortable:hover { color: var(--text); }
+thead th.sortable::after { content: ' ⇅'; opacity: .3; font-size: 10px; }
+thead th.sort-asc::after { content: ' ↑'; opacity: 1; color: var(--accent); }
+thead th.sort-desc::after { content: ' ↓'; opacity: 1; color: var(--accent); }
 
-thead th:hover { color: var(--text-primary); }
-
-tbody tr {
-  border-bottom: 1px solid var(--border);
-  transition: background 0.15s;
-  cursor: pointer;
-}
-
-tbody tr:hover { background: var(--bg-tertiary); }
+tbody tr { border-bottom: 1px solid var(--border); cursor: pointer; transition: background .1s; }
 tbody tr:last-child { border-bottom: none; }
+tbody tr:hover { background: var(--surface-2); }
+tbody td { padding: 12px 14px; font-size: 13px; vertical-align: middle; }
 
-tbody td {
-  padding: 12px 16px;
-  font-size: 14px;
-}
+td.cell-sev { position: relative; padding-left: 18px; }
+td.cell-sev::before { content: ''; position: absolute; left: 0; top: 8px; bottom: 8px; width: 4px; border-radius: 2px; }
+tr[data-severity="Critical"] td.cell-sev::before { background: var(--sev-critical); }
+tr[data-severity="High"] td.cell-sev::before { background: var(--sev-high); }
+tr[data-severity="Medium"] td.cell-sev::before { background: var(--sev-medium); }
+tr[data-severity="Low"] td.cell-sev::before { background: var(--sev-low); }
+tr[data-severity="None"] td.cell-sev::before { background: var(--sev-none); }
 
-/* Severity indicator */
-.severity-bar {
-  width: 4px;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-}
+.cve-id { font-family: var(--mono); font-size: 12.5px; font-weight: 600; color: var(--accent); white-space: nowrap; }
+.title-cell { max-width: 420px; }
+.title-text { color: var(--text); font-weight: 500; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-tr[data-severity="Critical"] { border-left: 3px solid var(--critical); }
-tr[data-severity="High"] { border-left: 3px solid var(--high); }
-tr[data-severity="Medium"] { border-left: 3px solid var(--medium); }
-tr[data-severity="Low"] { border-left: 3px solid var(--low); }
+.score-chip { display: inline-flex; align-items: center; gap: 7px; font-variant-numeric: tabular-nums; }
+.score-num { font-weight: 700; font-size: 13.5px; width: 30px; }
+.score-track { width: 44px; height: 5px; background: var(--surface-3); border-radius: 999px; overflow: hidden; }
+.score-track > span { display: block; height: 100%; border-radius: 999px; }
+.epss-cell { font-variant-numeric: tabular-nums; color: var(--text-muted); font-size: 12.5px; }
+.vendor-cell { color: var(--text-muted); font-size: 12.5px; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.date-cell { color: var(--text-faint); font-size: 12px; white-space: nowrap; }
 
-.badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: 600;
-}
+/* ---------- Badges ---------- */
+.badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 700; white-space: nowrap; line-height: 1.5; }
+.badge-sev { padding: 3px 10px; }
+.sev-Critical { background: color-mix(in srgb, var(--sev-critical) 18%, transparent); color: var(--sev-critical); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sev-critical) 35%, transparent); }
+.sev-High { background: color-mix(in srgb, var(--sev-high) 18%, transparent); color: var(--sev-high); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sev-high) 35%, transparent); }
+.sev-Medium { background: color-mix(in srgb, var(--sev-medium) 16%, transparent); color: var(--sev-medium); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sev-medium) 32%, transparent); }
+.sev-Low { background: color-mix(in srgb, var(--sev-low) 16%, transparent); color: var(--sev-low); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sev-low) 32%, transparent); }
+.sev-None { background: color-mix(in srgb, var(--sev-none) 16%, transparent); color: var(--sev-none); }
 
-.badge-critical { background: rgba(255,68,68,0.2); color: var(--critical); }
-.badge-high { background: rgba(255,136,0,0.2); color: var(--high); }
-.badge-medium { background: rgba(255,204,0,0.15); color: #d4a800; }
-.badge-low { background: rgba(68,187,68,0.2); color: var(--low); }
-.badge-kev { background: rgba(255,68,68,0.3); color: #ff6666; }
-.badge-none { background: rgba(139,148,158,0.2); color: var(--text-secondary); }
-.badge-ssvc { background: rgba(255,68,68,0.25); color: #ff5252; margin-left: 4px; }
-.badge-msf { background: rgba(139,0,0,0.35); color: #ff8080; margin-left: 4px; }
-.badge-edb { background: rgba(255,136,0,0.2); color: var(--high); margin-left: 4px; }
+.sig-badges { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.badge-kev { background: color-mix(in srgb, var(--sig-kev) 20%, transparent); color: var(--sig-kev); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-kev) 40%, transparent); }
+.badge-msf { background: color-mix(in srgb, var(--sig-msf) 20%, transparent); color: var(--sig-msf); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-msf) 40%, transparent); }
+.badge-edb { background: color-mix(in srgb, var(--sig-edb) 20%, transparent); color: var(--sig-edb); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-edb) 40%, transparent); }
+.badge-poc { background: color-mix(in srgb, var(--sig-poc) 18%, transparent); color: var(--sig-poc); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-poc) 38%, transparent); }
+.badge-ssvc { background: color-mix(in srgb, var(--sig-kev) 20%, transparent); color: var(--sig-kev); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-kev) 40%, transparent); }
 
-.cve-id {
-  font-family: 'SFMono-Regular', Consolas, monospace;
-  color: var(--info);
-  font-weight: 500;
-}
+/* ---------- Pagination ---------- */
+.pagination { display: flex; align-items: center; justify-content: center; gap: 14px; margin-top: 20px; }
+.pagination button { padding: 8px 16px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text); font-size: 13px; font-weight: 600; font-family: inherit; cursor: pointer; transition: all .12s; }
+.pagination button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.pagination button:disabled { opacity: .35; cursor: not-allowed; }
+.page-info { font-size: 13px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
 
-.vendor-product {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
+.loading { text-align: center; padding: 40px; color: var(--text-muted); }
+.empty-state { text-align: center; padding: 56px 20px !important; color: var(--text-muted); }
+.empty-state .icon { font-size: 40px; margin-bottom: 12px; opacity: .5; }
 
-.score-cell { font-weight: 600; font-family: monospace; }
-
-/* ===== Modal ===== */
-.modal-overlay {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.6);
-  z-index: 200;
-  justify-content: center;
-  align-items: flex-start;
-  padding: 40px 20px;
-  overflow-y: auto;
-}
-
+/* ---------- Modal ---------- */
+.modal-overlay { position: fixed; inset: 0; background: rgba(3,6,12,.7); backdrop-filter: blur(4px); display: none; align-items: flex-start; justify-content: center; z-index: 100; padding: 40px 20px; overflow-y: auto; }
 .modal-overlay.active { display: flex; }
+.modal { background: var(--surface); border: 1px solid var(--border-strong); border-radius: 16px; max-width: 760px; width: 100%; box-shadow: var(--shadow-lg); animation: modalIn .22s cubic-bezier(.2,.9,.3,1); }
+@keyframes modalIn { from { opacity: 0; transform: translateY(16px) scale(.98); } to { opacity: 1; transform: none; } }
+.modal-hero { padding: 22px 26px 18px; border-bottom: 1px solid var(--border); position: relative; }
+.modal-hero.h-Critical { background: linear-gradient(180deg, color-mix(in srgb, var(--sev-critical) 12%, transparent), transparent); }
+.modal-hero.h-High { background: linear-gradient(180deg, color-mix(in srgb, var(--sev-high) 12%, transparent), transparent); }
+.modal-hero.h-Medium { background: linear-gradient(180deg, color-mix(in srgb, var(--sev-medium) 10%, transparent), transparent); }
+.modal-hero.h-Low { background: linear-gradient(180deg, color-mix(in srgb, var(--sev-low) 10%, transparent), transparent); }
+.modal-hero-top { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
+.modal-hero .m-id { font-family: var(--mono); font-size: 14px; font-weight: 700; color: var(--accent); }
+.modal-hero h2 { font-size: 18px; font-weight: 700; letter-spacing: -.01em; color: var(--text); }
+.modal-close { position: absolute; top: 18px; right: 18px; width: 32px; height: 32px; border-radius: 8px; background: var(--surface-2); border: 1px solid var(--border); color: var(--text-muted); font-size: 20px; cursor: pointer; line-height: 1; display: grid; place-items: center; transition: all .12s; }
+.modal-close:hover { color: var(--text); border-color: var(--border-strong); }
+.modal-scores { display: flex; gap: 22px; margin-top: 12px; flex-wrap: wrap; }
+.mscore { display: flex; flex-direction: column; }
+.mscore .lbl { font-size: 11px; color: var(--text-muted); font-weight: 600; }
+.mscore .vl { font-size: 20px; font-weight: 800; font-variant-numeric: tabular-nums; letter-spacing: -.02em; }
+.modal-body { padding: 20px 26px 26px; }
+.report-link-primary { display: flex; align-items: center; gap: 8px; padding: 13px 16px; margin-bottom: 18px; background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), var(--surface-2)); border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border)); border-radius: var(--radius-sm); color: var(--accent); font-weight: 600; font-size: 13.5px; text-decoration: none; transition: all .12s; }
+.report-link-primary:hover { border-color: var(--accent); transform: translateY(-1px); }
+.detail-grid { display: grid; grid-template-columns: 120px 1fr; }
+.detail-row { display: contents; }
+.detail-row > .detail-label { padding: 11px 0; font-size: 12.5px; color: var(--text-muted); font-weight: 600; border-top: 1px solid var(--border); }
+.detail-row > .detail-value { padding: 11px 0 11px 16px; font-size: 13.5px; color: var(--text); border-top: 1px solid var(--border); word-break: break-word; line-height: 1.6; }
+.detail-row:first-child > .detail-label, .detail-row:first-child > .detail-value { border-top: none; }
+.detail-value code, .cwe-chip { font-family: var(--mono); font-size: 12px; background: var(--surface-3); padding: 1px 6px; border-radius: 5px; color: var(--text-muted); }
+.affected-item { padding: 2px 0; }
+.affected-item b { color: var(--text); }
+.rules-section { margin-top: 20px; }
+.rules-section > h3 { font-size: 14px; font-weight: 700; margin-bottom: 12px; color: var(--text); }
+.rule-block { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); margin-bottom: 12px; overflow: hidden; }
+.rule-header { display: flex; align-items: center; gap: 8px; padding: 10px 12px; flex-wrap: wrap; background: var(--surface-3); border-bottom: 1px solid var(--border); }
+.rule-title { font-weight: 700; font-size: 12.5px; color: var(--text); }
+.trust-badge { font-size: 10.5px; font-weight: 700; padding: 2px 7px; border-radius: 5px; }
+.trust-official { background: color-mix(in srgb, var(--sev-low) 18%, transparent); color: var(--sev-low); }
+.trust-validated { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+.trust-draft { background: color-mix(in srgb, var(--sev-medium) 16%, transparent); color: var(--sev-medium); }
+.rule-source { font-size: 11px; color: var(--text-faint); }
+.copy-btn { margin-left: auto; padding: 4px 10px; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; color: var(--text-muted); font-size: 11px; font-family: inherit; cursor: pointer; transition: all .12s; }
+.copy-btn:hover { color: var(--accent); border-color: var(--accent); }
+.rule-license { padding: 6px 12px; font-size: 11px; color: var(--text-faint); border-bottom: 1px solid var(--border); }
+.rule-preview { padding: 12px; font-family: var(--mono); font-size: 11.5px; line-height: 1.6; color: var(--text-muted); overflow-x: auto; white-space: pre; }
+.no-rules { color: var(--text-faint); font-size: 13px; padding: 8px 0; }
 
-.modal {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  max-width: 800px;
-  width: 100%;
-  max-height: 85vh;
-  overflow-y: auto;
+/* ---------- Responsive ---------- */
+@media (max-width: 1024px) {
+  .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+  .panels { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) {
+  .container { padding: 0 14px; }
+  .kpi-grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .kpi .kpi-value { font-size: 24px; }
+  thead th { top: 0; }
+  .detail-grid { grid-template-columns: 1fr; }
+  .detail-row > .detail-value { padding-left: 0; }
+  .filter-spacer { display: none; }
 }
 
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 24px;
-  border-bottom: 1px solid var(--border);
-}
-
-.modal-header h2 { font-size: 18px; }
-
-.modal-close {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  font-size: 24px;
-  cursor: pointer;
-  padding: 4px 8px;
-}
-
-.modal-close:hover { color: var(--text-primary); }
-
-.modal-body { padding: 24px; }
-
-.modal-body .detail-row {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 12px;
-}
-
-.modal-body .detail-label {
-  font-size: 12px;
-  color: var(--text-muted);
-  min-width: 80px;
-  text-transform: uppercase;
-}
-
-.modal-body .detail-value { font-size: 14px; }
-
-.report-link {
-  display: inline-block;
-  margin-top: 16px;
-  padding: 10px 20px;
-  background: var(--accent);
-  color: #fff;
-  text-decoration: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-}
-
-.report-link:hover { background: #388bfd; }
-
-/* 상세 리포트 배너 (모달 상단 — AI 분석 전문은 GitHub Issue에) */
-.report-link-primary {
-  display: block;
-  text-align: center;
-  margin-bottom: 20px;
-  padding: 12px 20px;
-  background: var(--accent);
-  color: #fff;
-  text-decoration: none;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  transition: background 0.2s;
-}
-
-.report-link-primary:hover { background: #388bfd; }
-
-/* ===== 탐지 룰 섹션 (모달) ===== */
-.rules-section {
-  margin-top: 20px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
-}
-
-.rules-section h3 {
-  font-size: 14px;
-  color: var(--text-secondary);
-  margin-bottom: 12px;
-}
-
-.rule-block { margin-bottom: 16px; }
-
-.rule-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-bottom: 6px;
-}
-
-.rule-title { font-weight: 600; font-size: 13px; }
-
-.rule-source {
-  font-size: 11px;
-  color: var(--text-muted);
-  flex: 1;
-}
-
-.rule-license {
-  font-size: 11px;
-  color: var(--text-muted);
-  margin-bottom: 6px;
-}
-
-.trust-badge {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.trust-official { background: rgba(68,187,68,0.2); color: var(--low); }
-.trust-validated { background: rgba(88,166,255,0.2); color: var(--info); }
-.trust-draft { background: rgba(255,136,0,0.2); color: var(--high); }
-
-.copy-btn {
-  padding: 4px 10px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  white-space: nowrap;
-}
-
-.copy-btn:hover { border-color: var(--accent); color: var(--text-primary); }
-.copy-btn:disabled { opacity: 0.7; cursor: default; }
-
-.skip-reasons {
-  margin-top: 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px;
-}
-
-.skip-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 6px;
-}
-
-.skip-item {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-bottom: 4px;
-  line-height: 1.5;
-}
-
-.export-group { display: flex; gap: 4px; }
-
-.export-btn.export-highrisk {
-  border-color: var(--critical);
-  color: var(--critical);
-  font-weight: 700;
-}
-.export-btn.export-highrisk:hover {
-  background: rgba(255,68,68,0.12);
-  color: #ff6666;
-}
-
-/* ===== Pagination ===== */
-.pagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  padding: 20px;
-}
-
-.pagination button {
-  padding: 8px 16px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 14px;
-  cursor: pointer;
-}
-
-.pagination button:hover { border-color: var(--accent); }
-.pagination button:disabled { opacity: 0.4; cursor: default; }
-.pagination .page-info { font-size: 14px; color: var(--text-secondary); }
-
-/* ===== Empty State ===== */
-.empty-state {
-  text-align: center;
-  padding: 60px 20px;
-  color: var(--text-muted);
-}
-
-.empty-state .icon { font-size: 48px; margin-bottom: 12px; }
-.empty-state p { font-size: 16px; }
-
-/* ===== Loading ===== */
-.loading {
-  text-align: center;
-  padding: 40px;
-  color: var(--text-muted);
-}
-
-/* ===== IOC Dashboard ===== */
-.type-tab:hover { border-color: var(--info) !important; }
-.type-tab.active { background: var(--info) !important; color: #fff !important; border-color: var(--info) !important; }
-.type-tab.active span { color: rgba(255,255,255,.8) !important; }
-
-.ioc-type-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.ioc-type-cve { background: rgba(88,166,255,0.15); color: var(--info); }
-.ioc-type-ip { background: rgba(255,136,0,0.15); color: var(--high); }
-.ioc-type-rule { background: rgba(68,187,68,0.15); color: var(--low); }
-.ioc-type-url { background: rgba(224,64,251,0.15); color: #E040FB; }
-.ioc-type-hash { background: rgba(255,82,82,0.15); color: #FF5252; }
-
-.ioc-tag {
-  display: inline-block;
-  padding: 3px 10px;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.ioc-tag-sm {
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 8px;
-  font-size: 10px;
-  font-weight: 500;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
-}
-
-.export-btn {
-  padding: 6px 14px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.export-btn:hover {
-  border-color: var(--accent);
-  color: var(--text-primary);
-}
-
-.rule-preview {
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px;
-  font-size: 12px;
-  font-family: 'SFMono-Regular', Consolas, monospace;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
-  max-height: 300px;
-  overflow-y: auto;
-  color: var(--text-primary);
-}
-
-/* ===== Responsive ===== */
-@media (max-width: 768px) {
-  .container { padding: 0 12px; }
-  .header-inner { flex-wrap: wrap; gap: 8px; }
-  .stat-cards { grid-template-columns: repeat(2, 1fr); gap: 8px; }
-  .stat-card .value { font-size: 24px; }
-  .filter-bar { flex-direction: column; }
-  .search-input { min-width: unset; width: 100%; }
-  .severity-filters { width: 100%; justify-content: center; }
-  .table-wrapper { overflow-x: auto; }
-  table { min-width: 700px; }
-  .modal { margin: 10px; }
-}
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 999px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-thumb:hover { background: var(--text-faint); }

--- a/docs/cve.html
+++ b/docs/cve.html
@@ -3,120 +3,142 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Argus - CVE Dashboard</title>
+  <title>Argus · CVE Threat Dashboard</title>
+  <meta name="description" content="CVE 취약점 위협 인텔리전스 대시보드 — 실제 악용·무기화·고위험 취약점을 한눈에.">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%231f6feb' d='M12 2 4 5v6c0 5 3.4 9.7 8 11 4.6-1.3 8-6 8-11V5z'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <!-- Header -->
   <header class="header">
     <div class="container header-inner">
       <a href="cve.html" class="logo">
-        <span class="logo-icon">&#128737;</span>
-        <span>Argus Dashboard</span>
+        <span class="logo-badge">&#128737;</span>
+        <span>Argus<small>CVE Threat Intelligence</small></span>
       </a>
-      <nav class="nav">
-        <a href="cve.html" class="active">CVE</a>
-      </nav>
-      <span class="updated-at" id="updated-time">-</span>
+      <div class="header-spacer"></div>
+      <div class="header-meta">
+        <span class="live-dot">자동 수집 중</span>
+        <span class="updated-at">업데이트 <b id="updated-time">-</b></span>
+      </div>
     </div>
   </header>
 
   <main class="container">
-    <!-- Stat Cards -->
-    <div class="stat-cards">
-      <div class="stat-card">
-        <div class="label">Total CVEs</div>
-        <div class="value info" id="stat-total">-</div>
+    <!-- KPI strip (위협 중심) -->
+    <section class="kpi-grid">
+      <div class="kpi is-new">
+        <div class="kpi-label">전체 추적 CVE</div>
+        <div class="kpi-value" id="stat-total">-</div>
+        <div class="kpi-sub" id="stat-24h-sub">최근 24시간 - 건 신규</div>
       </div>
-      <div class="stat-card">
-        <div class="label">High Risk (CVSS 7+)</div>
-        <div class="value high" id="stat-high">-</div>
+      <div class="kpi is-critical">
+        <div class="kpi-label">🔴 Critical</div>
+        <div class="kpi-value c-critical" id="stat-critical">-</div>
+        <div class="kpi-sub">CVSS 9+ · 즉시 대응 권고</div>
       </div>
-      <div class="stat-card">
-        <div class="label">KEV Listed</div>
-        <div class="value kev" id="stat-kev">-</div>
+      <div class="kpi is-kev">
+        <div class="kpi-label">🚨 실제 악용 (KEV)</div>
+        <div class="kpi-value c-kev" id="stat-kev">-</div>
+        <div class="kpi-sub">CISA 확인 · 악용 진행형</div>
       </div>
-      <div class="stat-card">
-        <div class="label">Last 24h</div>
-        <div class="value info" id="stat-24h">-</div>
+      <div class="kpi is-weapon">
+        <div class="kpi-label">🧨 무기화됨</div>
+        <div class="kpi-value c-weapon" id="stat-weapon">-</div>
+        <div class="kpi-sub">Metasploit · ExploitDB 공개</div>
       </div>
-    </div>
+      <div class="kpi">
+        <div class="kpi-label">⚠️ High</div>
+        <div class="kpi-value" id="stat-high">-</div>
+        <div class="kpi-sub">CVSS 7 – 8.9</div>
+      </div>
+    </section>
 
-    <!-- Charts Row -->
-    <div style="display:grid;grid-template-columns:2fr 1fr;gap:16px;margin-bottom:24px;">
-      <div class="chart-section">
-        <h3>CVE Daily Trend (Last 30 Days)</h3>
-        <div class="chart-container">
-          <canvas id="trend-chart"></canvas>
-        </div>
+    <!-- Panels: trend + distribution -->
+    <section class="panels">
+      <div class="panel">
+        <h3>📈 일별 탐지 추이 <span style="font-weight:500;color:var(--text-faint);text-transform:none;letter-spacing:0;">최근 30일</span></h3>
+        <div class="chart-container"><canvas id="trend-chart"></canvas></div>
       </div>
-      <div class="chart-section">
-        <h3>Severity Distribution</h3>
-        <div id="severity-dist" style="padding-top:16px;"></div>
-        <h3 style="margin-top:20px;">Top Vendors</h3>
-        <div id="vendor-dist" style="padding-top:8px;"></div>
+      <div class="panel">
+        <h3>심각도 분포</h3>
+        <div id="severity-dist"></div>
+        <h3 class="mt">영향 벤더 TOP</h3>
+        <div id="vendor-dist"></div>
       </div>
-    </div>
+    </section>
 
-    <!-- Filter Bar -->
-    <div class="filter-bar">
-      <input type="text" class="search-input" id="search-input" placeholder="CVE ID or keyword...">
-      <select class="filter-select" id="vendor-filter">
-        <option value="">All Vendors</option>
-      </select>
-      <select class="filter-select" id="month-filter" title="월별 필터">
-        <option value="">All Months</option>
-      </select>
-      <div class="severity-filters">
-        <button class="severity-btn active" data-severity="Critical">Critical</button>
-        <button class="severity-btn active" data-severity="High">High</button>
-        <button class="severity-btn active" data-severity="Medium">Medium</button>
-        <button class="severity-btn active" data-severity="Low">Low</button>
+    <!-- Filter bar -->
+    <section class="filter-bar">
+      <div class="search-wrap">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input type="text" class="search-input" id="search-input" placeholder="CVE ID · 제품 · 키워드 검색…">
       </div>
+
+      <div class="seg" id="severity-seg">
+        <button class="seg-btn active sev-c-critical" data-severity="Critical"><span class="dot" style="background:var(--sev-critical)"></span>Critical</button>
+        <button class="seg-btn active sev-c-high" data-severity="High"><span class="dot" style="background:var(--sev-high)"></span>High</button>
+        <button class="seg-btn active sev-c-medium" data-severity="Medium"><span class="dot" style="background:var(--sev-medium)"></span>Medium</button>
+        <button class="seg-btn active sev-c-low" data-severity="Low"><span class="dot" style="background:var(--sev-low)"></span>Low</button>
+      </div>
+
+      <button class="signal-toggle" data-signal="kev">🚨 악용 중</button>
+      <button class="signal-toggle" data-signal="weaponized">🧨 무기화</button>
+      <button class="signal-toggle" data-signal="poc">🔬 PoC</button>
+
+      <select class="filter-select" id="vendor-filter"><option value="">전체 벤더</option></select>
+      <select class="filter-select" id="month-filter" title="월별 필터"><option value="">전체 기간</option></select>
+
+      <div class="filter-spacer"></div>
       <div class="export-group">
-        <button class="export-btn export-highrisk" onclick="exportHighRiskByMonth()" title="선택한 월의 고위험(Critical/High) CVE를 CSV로 다운로드">고위험 CSV &#8595;</button>
-        <button class="export-btn" onclick="exportData('csv')" title="필터된 목록을 CSV로 다운로드">CSV &#8595;</button>
-        <button class="export-btn" onclick="exportData('json')" title="필터된 목록을 JSON으로 다운로드">JSON &#8595;</button>
-        <button class="export-btn" onclick="exportData('stix')" title="필터된 목록을 STIX 2.1 번들로 다운로드">STIX 2.1 &#8595;</button>
+        <button class="export-btn export-highrisk" onclick="exportHighRiskByMonth()" title="선택 월의 고위험(Critical/High)을 CSV로">고위험 CSV ↓</button>
+        <button class="export-btn" onclick="exportData('csv')" title="필터된 목록 CSV">CSV</button>
+        <button class="export-btn" onclick="exportData('json')" title="필터된 목록 JSON">JSON</button>
+        <button class="export-btn" onclick="exportData('stix')" title="필터된 목록 STIX 2.1">STIX</button>
       </div>
-    </div>
+    </section>
 
-    <!-- Loading -->
-    <div class="loading" id="loading">Loading...</div>
+    <div class="loading" id="loading">불러오는 중…</div>
 
     <!-- Table -->
-    <div class="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th onclick="sortBy('id')">CVE ID</th>
-            <th>Title</th>
-            <th>Severity</th>
-            <th onclick="sortBy('cvss')">CVSS</th>
-            <th onclick="sortBy('epss')">EPSS</th>
-            <th>KEV</th>
-            <th>Vendor / Product</th>
-            <th onclick="sortBy('date')">Date</th>
-          </tr>
-        </thead>
-        <tbody id="cve-table-body"></tbody>
-      </table>
+    <div class="table-wrap">
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th class="cell-sev sortable" data-sort="cvss">심각도</th>
+              <th class="sortable" data-sort="id">CVE ID</th>
+              <th>취약점</th>
+              <th class="sortable" data-sort="cvss">CVSS</th>
+              <th class="sortable" data-sort="epss">EPSS</th>
+              <th>위협 신호</th>
+              <th>영향 벤더</th>
+              <th class="sortable" data-sort="date">탐지일</th>
+            </tr>
+          </thead>
+          <tbody id="cve-table-body"></tbody>
+        </table>
+      </div>
     </div>
 
-    <!-- Pagination -->
     <div class="pagination">
-      <button id="prev-btn" onclick="changePage(-1)">&laquo; Prev</button>
+      <button id="prev-btn" onclick="changePage(-1)">&laquo; 이전</button>
       <span class="page-info" id="page-info">-</span>
-      <button id="next-btn" onclick="changePage(1)">Next &raquo;</button>
+      <button id="next-btn" onclick="changePage(1)">다음 &raquo;</button>
     </div>
   </main>
 
   <!-- Detail Modal -->
   <div class="modal-overlay" id="modal-overlay">
     <div class="modal">
-      <div class="modal-header">
-        <h2 id="modal-title">CVE Detail</h2>
+      <div class="modal-hero" id="modal-hero">
         <button class="modal-close" onclick="closeModal()">&times;</button>
+        <div class="modal-hero-top">
+          <span class="m-id" id="modal-id">CVE</span>
+          <span id="modal-sev-badge"></span>
+          <span class="sig-badges" id="modal-signals"></span>
+        </div>
+        <h2 id="modal-title">-</h2>
+        <div class="modal-scores" id="modal-scores"></div>
       </div>
       <div class="modal-body" id="modal-body"></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="refresh" content="0; url=cve.html">
-  <title>Argus Dashboard</title>
+  <link rel="canonical" href="cve.html">
+  <title>Argus · CVE Threat Dashboard</title>
+  <style>html,body{margin:0;height:100%;background:#0b0f16;color:#8b97a8;font-family:-apple-system,sans-serif;display:grid;place-items:center}</style>
 </head>
 <body>
-  <p>Redirecting to <a href="cve.html">CVE Dashboard</a>...</p>
+  <p>CVE 대시보드로 이동 중… <a href="cve.html" style="color:#58a6ff">여기</a>를 클릭하세요.</p>
 </body>
 </html>

--- a/docs/js/chart.js
+++ b/docs/js/chart.js
@@ -1,7 +1,11 @@
 /**
- * Argus Dashboard - 간단한 Canvas 기반 Bar Chart
- * 외부 라이브러리 없이 순수 Canvas API 사용
+ * Argus Dashboard — 외부 라이브러리 없는 Canvas 막대 차트 (호버 툴팁 포함)
  */
+
+function cssVar(name, fallback) {
+  const v = getComputedStyle(document.body).getPropertyValue(name).trim();
+  return v || fallback;
+}
 
 function drawBarChart(canvasId, data, options = {}) {
   const canvas = document.getElementById(canvasId);
@@ -9,104 +13,99 @@ function drawBarChart(canvasId, data, options = {}) {
 
   const ctx = canvas.getContext('2d');
   const dpr = window.devicePixelRatio || 1;
-
-  // Canvas 크기 설정 (HiDPI 대응)
   const rect = canvas.parentElement.getBoundingClientRect();
+  const h = options.height || 200;
   canvas.width = rect.width * dpr;
-  canvas.height = (options.height || 200) * dpr;
+  canvas.height = h * dpr;
   canvas.style.width = rect.width + 'px';
-  canvas.style.height = (options.height || 200) + 'px';
-  ctx.scale(dpr, dpr);
+  canvas.style.height = h + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
   const w = rect.width;
-  const h = options.height || 200;
-  const padding = { top: 20, right: 20, bottom: 40, left: 50 };
-  const chartW = w - padding.left - padding.right;
-  const chartH = h - padding.top - padding.bottom;
+  const pad = { top: 16, right: 12, bottom: 34, left: 34 };
+  const chartW = w - pad.left - pad.right;
+  const chartH = h - pad.top - pad.bottom;
 
-  // 최대값
   const values = data.map(d => d.value);
   const maxVal = Math.max(...values, 1);
+  const gridColor = cssVar('--border', '#232b39');
+  const axisText = cssVar('--text-faint', '#5c6675');
+  const barColor = cssVar('--accent', '#58a6ff');
 
-  // 배경 클리어
   ctx.clearRect(0, 0, w, h);
 
-  // Y축 가이드라인
-  ctx.strokeStyle = '#30363d';
-  ctx.lineWidth = 0.5;
-  ctx.fillStyle = '#6e7681';
-  ctx.font = '11px -apple-system, sans-serif';
+  // 가로 그리드 + Y 라벨
+  ctx.strokeStyle = gridColor;
+  ctx.lineWidth = 1;
+  ctx.fillStyle = axisText;
+  ctx.font = '10px -apple-system, sans-serif';
   ctx.textAlign = 'right';
-
   const ySteps = 4;
   for (let i = 0; i <= ySteps; i++) {
-    const y = padding.top + chartH - (chartH / ySteps) * i;
+    const y = pad.top + chartH - (chartH / ySteps) * i;
     const val = Math.round((maxVal / ySteps) * i);
-    ctx.beginPath();
-    ctx.moveTo(padding.left, y);
-    ctx.lineTo(w - padding.right, y);
-    ctx.stroke();
-    ctx.fillText(val.toString(), padding.left - 8, y + 4);
+    ctx.globalAlpha = 0.5;
+    ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(w - pad.right, y); ctx.stroke();
+    ctx.globalAlpha = 1;
+    ctx.fillText(String(val), pad.left - 7, y + 3);
   }
 
-  // 바 그리기
-  const barWidth = Math.max(4, (chartW / data.length) * 0.6);
   const gap = chartW / data.length;
+  const barW = Math.max(3, gap * 0.62);
+  const bars = [];
 
   data.forEach((d, i) => {
-    const x = padding.left + gap * i + (gap - barWidth) / 2;
-    const barH = (d.value / maxVal) * chartH;
-    const y = padding.top + chartH - barH;
+    const x = pad.left + gap * i + (gap - barW) / 2;
+    const barH = Math.max((d.value / maxVal) * chartH, d.value > 0 ? 2 : 0);
+    const y = pad.top + chartH - barH;
+    bars.push({ x, y, w: barW, h: barH, ...d });
 
-    // 바 색상
-    const color = d.color || options.barColor || '#1f6feb';
-    ctx.fillStyle = color;
-
-    // 둥근 모서리 바
-    const radius = Math.min(3, barWidth / 2);
+    const r = Math.min(4, barW / 2);
+    ctx.fillStyle = d.color || barColor;
     ctx.beginPath();
-    ctx.moveTo(x + radius, y);
-    ctx.lineTo(x + barWidth - radius, y);
-    ctx.quadraticCurveTo(x + barWidth, y, x + barWidth, y + radius);
-    ctx.lineTo(x + barWidth, padding.top + chartH);
-    ctx.lineTo(x, padding.top + chartH);
-    ctx.lineTo(x, y + radius);
-    ctx.quadraticCurveTo(x, y, x + radius, y);
+    ctx.moveTo(x, pad.top + chartH);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.lineTo(x + barW - r, y);
+    ctx.quadraticCurveTo(x + barW, y, x + barW, y + r);
+    ctx.lineTo(x + barW, pad.top + chartH);
+    ctx.closePath();
     ctx.fill();
 
-    // X축 라벨
-    ctx.fillStyle = '#6e7681';
-    ctx.font = '10px -apple-system, sans-serif';
-    ctx.textAlign = 'center';
-    const label = d.label || '';
-    // 짧은 라벨만 표시 (혼잡 방지)
-    if (data.length <= 15 || i % Math.ceil(data.length / 15) === 0) {
-      ctx.fillText(label.slice(5), x + barWidth / 2, h - padding.bottom + 18);
+    // X 라벨 (혼잡 방지: 최대 ~10개)
+    if (data.length <= 12 || i % Math.ceil(data.length / 10) === 0) {
+      ctx.fillStyle = axisText;
+      ctx.font = '9px -apple-system, sans-serif';
+      ctx.textAlign = 'center';
+      const lbl = (d.label || '').slice(5); // MM-DD
+      ctx.fillText(lbl, x + barW / 2, h - pad.bottom + 15);
     }
   });
-}
 
-// Severity 분포 도넛 (간이 버전 - 가로 바)
-function drawSeverityBars(containerId, counts) {
-  const container = document.getElementById(containerId);
-  if (!container) return;
-
-  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1;
-  const colors = { Critical: '#FF4444', High: '#FF8800', Medium: '#FFCC00', Low: '#44BB44' };
-  const order = ['Critical', 'High', 'Medium', 'Low'];
-
-  let html = '';
-  for (const sev of order) {
-    const count = counts[sev] || 0;
-    const pct = ((count / total) * 100).toFixed(1);
-    html += `
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
-        <span style="width:60px;font-size:12px;color:#8b949e;">${sev}</span>
-        <div style="flex:1;height:8px;background:#21262d;border-radius:4px;overflow:hidden;">
-          <div style="width:${pct}%;height:100%;background:${colors[sev]};border-radius:4px;"></div>
-        </div>
-        <span style="width:50px;font-size:12px;color:#e6edf3;text-align:right;">${count}</span>
-      </div>`;
+  // ---- 호버 툴팁 ----
+  let tip = canvas.parentElement.querySelector('.chart-tip');
+  if (!tip) {
+    tip = document.createElement('div');
+    tip.className = 'chart-tip';
+    tip.style.cssText = 'position:absolute;pointer-events:none;display:none;padding:5px 9px;border-radius:6px;font-size:11px;font-weight:600;white-space:nowrap;z-index:10;transform:translate(-50%,-120%);';
+    canvas.parentElement.style.position = 'relative';
+    canvas.parentElement.appendChild(tip);
   }
-  container.innerHTML = html;
+  canvas.onmousemove = (e) => {
+    const b = canvas.getBoundingClientRect();
+    const mx = e.clientX - b.left, my = e.clientY - b.top;
+    const hit = bars.find(bar => mx >= bar.x - 2 && mx <= bar.x + bar.w + 2 && my >= bar.y - 6);
+    if (hit) {
+      tip.style.display = 'block';
+      tip.style.left = (hit.x + hit.w / 2) + 'px';
+      tip.style.top = hit.y + 'px';
+      tip.style.background = cssVar('--surface-3', '#1b222e');
+      tip.style.color = cssVar('--text', '#e8eef6');
+      tip.style.boxShadow = '0 4px 14px rgba(0,0,0,.35)';
+      tip.textContent = `${hit.label} · ${hit.value}건`;
+    } else {
+      tip.style.display = 'none';
+    }
+  };
+  canvas.onmouseleave = () => { tip.style.display = 'none'; };
 }

--- a/docs/js/cve-dashboard.js
+++ b/docs/js/cve-dashboard.js
@@ -1,6 +1,6 @@
 /**
- * Argus CVE Dashboard
- * 검색, 필터, 정렬, 페이지네이션
+ * Argus CVE Dashboard — 위협 중심 재설계
+ * 검색·심각도·위협신호 필터, 정렬, 페이지네이션, 모달, export.
  */
 
 let allCves = [];
@@ -10,7 +10,14 @@ let currentPage = 1;
 const PAGE_SIZE = 50;
 let sortField = 'date';
 let sortDir = -1; // -1 = desc
-let activeFilters = { severity: new Set(['Critical', 'High', 'Medium', 'Low', 'None']), search: '', vendor: '', month: '' };
+let activeFilters = {
+  severity: new Set(['Critical', 'High', 'Medium', 'Low', 'None']),
+  signals: new Set(),   // 'kev' | 'weaponized' | 'poc'
+  search: '', vendor: '', month: '',
+};
+
+const SEV_VAR = { Critical: '--sev-critical', High: '--sev-high', Medium: '--sev-medium', Low: '--sev-low', None: '--sev-none' };
+const sevColor = s => `var(${SEV_VAR[s] || '--sev-none'})`;
 
 // ===== 초기화 =====
 async function init() {
@@ -30,7 +37,7 @@ async function init() {
   } catch (e) {
     console.error('Data load failed:', e);
     document.getElementById('cve-table-body').innerHTML =
-      '<tr><td colspan="7" class="empty-state"><div class="icon">&#128268;</div><p>데이터를 불러올 수 없습니다. GitHub Actions에서 export를 실행해주세요.</p></td></tr>';
+      '<tr><td colspan="8" class="empty-state"><div class="icon">&#128268;</div><p>데이터를 불러올 수 없습니다. GitHub Actions에서 export를 실행해주세요.</p></td></tr>';
   }
   showLoading(false);
 }
@@ -40,51 +47,57 @@ function showLoading(show) {
   if (el) el.style.display = show ? 'block' : 'none';
 }
 
-// ===== 통계 카드 =====
+// ===== KPI =====
 function renderStats() {
   const s = statsData.cve || {};
+  const critical = s.severity?.Critical || allCves.filter(c => c.severity === 'Critical').length;
+  const high = s.severity?.High || allCves.filter(c => c.severity === 'High').length;
+  const weapon = allCves.filter(c => c.has_metasploit_module || c.has_public_exploit).length;
+
   setText('stat-total', s.total || allCves.length);
-  setText('stat-high', (s.severity?.Critical || 0) + (s.severity?.High || 0));
-  setText('stat-kev', s.kev_count || 0);
-  setText('stat-24h', s.recent_24h || 0);
+  setText('stat-critical', critical);
+  setText('stat-kev', s.kev_count || allCves.filter(c => c.is_kev).length);
+  setText('stat-weapon', weapon);
+  setText('stat-high', high);
+  const sub = document.getElementById('stat-24h-sub');
+  if (sub) sub.textContent = `최근 24시간 ${(s.recent_24h || 0).toLocaleString()}건 신규`;
 
-  // 업데이트 시간
   if (statsData.generated_at) {
-    const d = new Date(statsData.generated_at);
-    setText('updated-time', d.toLocaleString('ko-KR'));
+    setText('updated-time', new Date(statsData.generated_at).toLocaleString('ko-KR', { dateStyle: 'short', timeStyle: 'short' }));
   }
+  if (s.severity) drawSeverityBars('severity-dist', s.severity);
+  if (s.top_vendors?.length) renderVendorBars(s.top_vendors);
+}
 
-  // 심각도 분포 바
-  if (s.severity) {
-    drawSeverityBars('severity-dist', s.severity);
-  }
-
-  // Top Vendors 바
-  if (s.top_vendors && s.top_vendors.length > 0) {
-    renderVendorBars(s.top_vendors);
-  }
+function drawSeverityBars(containerId, counts) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const order = ['Critical', 'High', 'Medium', 'Low'];
+  const total = order.reduce((a, s) => a + (counts[s] || 0), 0) || 1;
+  container.innerHTML = order.map(sev => {
+    const count = counts[sev] || 0;
+    const pct = ((count / total) * 100).toFixed(1);
+    return `<div class="dist-row">
+      <span class="dist-name"><span class="dot" style="background:${sevColor(sev)}"></span>${sev}</span>
+      <div class="dist-track"><div class="dist-fill" style="width:${pct}%;background:${sevColor(sev)}"></div></div>
+      <span class="dist-count">${count}</span>
+    </div>`;
+  }).join('');
 }
 
 function renderVendorBars(vendors) {
   const container = document.getElementById('vendor-dist');
   if (!container) return;
-
-  const maxCount = vendors[0]?.count || 1;
-  let html = '';
-  for (const v of vendors.slice(0, 7)) {
-    const pct = ((v.count / maxCount) * 100).toFixed(1);
-    const safeName = escapeHtml(v.vendor || '');
-    const displayName = safeName.length > 15 ? safeName.slice(0, 15) + '...' : safeName;
-    html += `
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
-        <span style="width:100px;font-size:11px;color:#8b949e;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${safeName}">${displayName}</span>
-        <div style="flex:1;height:6px;background:#21262d;border-radius:3px;overflow:hidden;">
-          <div style="width:${pct}%;height:100%;background:#1f6feb;border-radius:3px;"></div>
-        </div>
-        <span style="width:30px;font-size:11px;color:#e6edf3;text-align:right;">${Number(v.count) || 0}</span>
-      </div>`;
-  }
-  container.innerHTML = html;
+  const max = vendors[0]?.count || 1;
+  container.innerHTML = vendors.slice(0, 6).map(v => {
+    const pct = ((v.count / max) * 100).toFixed(1);
+    const name = escapeHtml(v.vendor || '');
+    return `<div class="dist-row">
+      <span class="dist-name" title="${name}">${name}</span>
+      <div class="dist-track"><div class="dist-fill" style="width:${pct}%;background:var(--accent)"></div></div>
+      <span class="dist-count">${Number(v.count) || 0}</span>
+    </div>`;
+  }).join('');
 }
 
 function setText(id, val) {
@@ -95,24 +108,16 @@ function setText(id, val) {
 // ===== 차트 =====
 function renderChart() {
   const trend = statsData.cve?.daily_trend || [];
-  const chartData = trend.map(d => ({
-    label: d.date,
-    value: d.count,
-    color: '#1f6feb',
-  }));
-  drawBarChart('trend-chart', chartData);
+  drawBarChart('trend-chart', trend.map(d => ({ label: d.date, value: d.count })));
 }
 
-// ===== 벤더 필터 =====
+// ===== 필터 소스 =====
 function buildVendorFilter() {
   const vendors = new Map();
-  allCves.forEach(cve => {
-    (cve.affected || []).forEach(a => {
-      const v = a.vendor;
-      if (v && v !== 'Unknown') vendors.set(v, (vendors.get(v) || 0) + 1);
-    });
-  });
-
+  allCves.forEach(cve => (cve.affected || []).forEach(a => {
+    const v = a.vendor;
+    if (v && v !== 'Unknown') vendors.set(v, (vendors.get(v) || 0) + 1);
+  }));
   const sorted = [...vendors.entries()].sort((a, b) => b[1] - a[1]).slice(0, 30);
   const select = document.getElementById('vendor-filter');
   if (!select) return;
@@ -124,10 +129,7 @@ function buildVendorFilter() {
   });
 }
 
-// ===== 월별 필터 =====
-function cveMonth(cve) {
-  return (cve.date || '').slice(0, 7); // 'YYYY-MM'
-}
+const cveMonth = cve => (cve.date || '').slice(0, 7);
 
 function buildMonthFilter() {
   const months = [...new Set(allCves.map(cveMonth).filter(Boolean))].sort().reverse();
@@ -135,53 +137,48 @@ function buildMonthFilter() {
   if (!select) return;
   months.forEach(m => {
     const opt = document.createElement('option');
-    opt.value = m;
-    opt.textContent = m;
+    opt.value = m; opt.textContent = m;
     select.appendChild(opt);
   });
 }
 
 // ===== 필터링 =====
+function cveHasSignal(cve, sig) {
+  if (sig === 'kev') return cve.is_kev || cve.ssvc_exploitation === 'active';
+  if (sig === 'weaponized') return cve.has_metasploit_module || cve.has_public_exploit;
+  if (sig === 'poc') return cve.has_poc;
+  return true;
+}
+
 function applyFilters() {
   const search = activeFilters.search.toLowerCase();
   const vendor = activeFilters.vendor.toLowerCase();
   const month = activeFilters.month;
 
   filteredCves = allCves.filter(cve => {
-    // 심각도 필터
     if (!activeFilters.severity.has(cve.severity || 'None')) return false;
-
-    // 월별 필터
     if (month && cveMonth(cve) !== month) return false;
-
-    // 검색
+    if (activeFilters.signals.size) {
+      for (const sig of activeFilters.signals) if (!cveHasSignal(cve, sig)) return false;
+    }
     if (search) {
-      const haystack = `${cve.id} ${cve.title} ${cve.description}`.toLowerCase();
-      if (!haystack.includes(search)) return false;
+      const hay = `${cve.id} ${cve.title} ${cve.description} ${(cve.affected || []).map(a => a.vendor + ' ' + a.product).join(' ')}`.toLowerCase();
+      if (!hay.includes(search)) return false;
     }
-
-    // 벤더 필터
     if (vendor) {
-      const match = (cve.affected || []).some(a =>
-        (a.vendor || '').toLowerCase().includes(vendor)
-      );
-      if (!match) return false;
+      if (!(cve.affected || []).some(a => (a.vendor || '').toLowerCase().includes(vendor))) return false;
     }
-
     return true;
   });
 
-  // 정렬
   filteredCves.sort((a, b) => {
     let va, vb;
     switch (sortField) {
       case 'cvss': va = a.cvss || 0; vb = b.cvss || 0; break;
       case 'epss': va = a.epss || 0; vb = b.epss || 0; break;
-      case 'date': va = a.date || ''; vb = b.date || ''; break;
       case 'id': va = a.id || ''; vb = b.id || ''; break;
       default: va = a.date || ''; vb = b.date || '';
     }
-    // sortDir: -1 = 내림차순(desc, 최신/큰 값 우선), 1 = 오름차순
     if (va < vb) return -sortDir;
     if (va > vb) return sortDir;
     return 0;
@@ -190,247 +187,186 @@ function applyFilters() {
   currentPage = 1;
   renderTable();
   renderPagination();
+  updateSortHeaders();
 }
 
-// ===== 테이블 렌더링 =====
+// ===== 테이블 =====
 function renderTable() {
   const tbody = document.getElementById('cve-table-body');
   if (!tbody) return;
-
   const start = (currentPage - 1) * PAGE_SIZE;
   const page = filteredCves.slice(start, start + PAGE_SIZE);
 
   if (page.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="7" class="empty-state"><div class="icon">&#128269;</div><p>조건에 맞는 CVE가 없습니다.</p></td></tr>';
+    tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="icon">&#128269;</div><p>조건에 맞는 CVE가 없습니다.</p></td></tr>';
     return;
   }
 
   tbody.innerHTML = page.map(cve => {
-    const sevClass = `badge-${(cve.severity || 'none').toLowerCase()}`;
+    const sev = cve.severity || 'None';
     const vendor = cve.affected?.[0]?.vendor || '-';
-    const product = cve.affected?.[0]?.product || '-';
-    const dateStr = cve.date ? new Date(cve.date).toLocaleDateString('ko-KR') : '-';
-    const kevBadge = cve.is_kev ? '<span class="badge badge-kev">KEV</span>' : '';
+    const product = cve.affected?.[0]?.product || '';
+    const vp = product && product !== '-' ? `${vendor} / ${product}` : vendor;
+    const dateStr = cve.date ? new Date(cve.date).toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' }) : '-';
+    const cvss = cve.cvss || 0;
+    const gaugePct = Math.min(100, (cvss / 10) * 100);
 
-    return `<tr data-severity="${cve.severity || 'None'}" onclick="showDetail('${cve.id}')">
+    return `<tr data-severity="${sev}" onclick="showDetail('${cve.id}')">
+      <td class="cell-sev"><span class="badge badge-sev sev-${sev}">${sev}</span></td>
       <td><span class="cve-id">${cve.id}</span></td>
-      <td>${escapeHtml(cve.title || 'N/A')}</td>
-      <td><span class="badge ${sevClass}">${cve.severity || '-'}</span></td>
-      <td class="score-cell">${(cve.cvss || 0).toFixed(1)}</td>
-      <td class="score-cell">${((cve.epss || 0) * 100).toFixed(2)}%</td>
-      <td>${kevBadge}${signalBadges(cve)}</td>
-      <td><span class="vendor-product">${escapeHtml(vendor)}/${escapeHtml(product)}</span></td>
-      <td>${dateStr}</td>
+      <td class="title-cell"><span class="title-text" title="${escapeHtml(cve.title || '')}">${escapeHtml(cve.title || 'N/A')}</span></td>
+      <td><span class="score-chip"><span class="score-num" style="color:${sevColor(sev)}">${cvss.toFixed(1)}</span><span class="score-track"><span style="width:${gaugePct}%;background:${sevColor(sev)}"></span></span></span></td>
+      <td class="epss-cell">${((cve.epss || 0) * 100).toFixed(1)}%</td>
+      <td><span class="sig-badges">${signalBadges(cve) || '<span style="color:var(--text-faint)">–</span>'}</span></td>
+      <td class="vendor-cell" title="${escapeHtml(vp)}">${escapeHtml(vp)}</td>
+      <td class="date-cell">${dateStr}</td>
     </tr>`;
   }).join('');
 }
 
-// ===== 위협 신호 배지 (P5: SSVC / Metasploit / ExploitDB) =====
 function signalBadges(cve) {
   let out = '';
-  if (cve.ssvc_exploitation === 'active') out += '<span class="badge badge-ssvc" title="CISA SSVC: 실제 악용 중">Active</span>';
-  if (cve.has_metasploit_module) out += '<span class="badge badge-msf" title="Metasploit 모듈 존재 — 무기화됨">MSF</span>';
+  if (cve.is_kev) out += '<span class="badge badge-kev" title="CISA KEV — 실제 악용 확인">KEV</span>';
+  if (cve.ssvc_exploitation === 'active' && !cve.is_kev) out += '<span class="badge badge-ssvc" title="CISA SSVC: 악용 진행형">Active</span>';
+  if (cve.has_metasploit_module) out += '<span class="badge badge-msf" title="Metasploit 모듈 — 무기화됨">MSF</span>';
   if (cve.has_public_exploit) out += '<span class="badge badge-edb" title="ExploitDB 공개 익스플로잇">EDB</span>';
+  if (cve.has_poc) out += '<span class="badge badge-poc" title="PoC 공개됨">PoC</span>';
   return out;
 }
 
 // ===== 페이지네이션 =====
 function renderPagination() {
-  const totalPages = Math.ceil(filteredCves.length / PAGE_SIZE);
+  const totalPages = Math.ceil(filteredCves.length / PAGE_SIZE) || 1;
   const info = document.getElementById('page-info');
-  const prevBtn = document.getElementById('prev-btn');
-  const nextBtn = document.getElementById('next-btn');
-
-  if (info) info.textContent = `${currentPage} / ${totalPages} (${filteredCves.length}건)`;
-  if (prevBtn) prevBtn.disabled = currentPage <= 1;
-  if (nextBtn) nextBtn.disabled = currentPage >= totalPages;
+  const prev = document.getElementById('prev-btn');
+  const next = document.getElementById('next-btn');
+  if (info) info.textContent = `${currentPage} / ${totalPages} · 총 ${filteredCves.length.toLocaleString()}건`;
+  if (prev) prev.disabled = currentPage <= 1;
+  if (next) next.disabled = currentPage >= totalPages;
 }
 
 function changePage(delta) {
-  const totalPages = Math.ceil(filteredCves.length / PAGE_SIZE);
+  const totalPages = Math.ceil(filteredCves.length / PAGE_SIZE) || 1;
   currentPage = Math.max(1, Math.min(totalPages, currentPage + delta));
   renderTable();
   renderPagination();
-  window.scrollTo({ top: document.querySelector('.table-wrapper')?.offsetTop - 80, behavior: 'smooth' });
+  window.scrollTo({ top: (document.querySelector('.table-wrap')?.offsetTop || 0) - 80, behavior: 'smooth' });
 }
 
 // ===== 정렬 =====
 function sortBy(field) {
-  if (sortField === field) {
-    sortDir *= -1;
-  } else {
-    sortField = field;
-    sortDir = -1;
-  }
+  if (sortField === field) sortDir *= -1;
+  else { sortField = field; sortDir = -1; }
   applyFilters();
 }
 
-// ===== 탐지 룰 렌더링 (trust 배지 + 라이선스 고지 + 복사) =====
+function updateSortHeaders() {
+  document.querySelectorAll('th.sortable').forEach(th => {
+    th.classList.remove('sort-asc', 'sort-desc');
+    if (th.dataset.sort === sortField) th.classList.add(sortDir === -1 ? 'sort-desc' : 'sort-asc');
+  });
+}
+
+// ===== 탐지 룰 (모달) =====
 const TRUST_LABELS = {
   'official-verified': { text: '🟢 공식 검증', cls: 'trust-official' },
-  'ai-validated': { text: '🔷 AI 생성 · 자기검증 통과', cls: 'trust-validated' },
-  'ai-draft': { text: '🔶 AI 생성 · 검토 필요', cls: 'trust-draft' },
+  'ai-validated': { text: '🔷 AI · 검증 통과', cls: 'trust-validated' },
+  'ai-draft': { text: '🔶 AI · 검토 필요', cls: 'trust-draft' },
 };
-
 function ruleTrust(info) {
   const t = info.trust || (info.verified ? 'official-verified' : 'ai-draft');
   return TRUST_LABELS[t] || TRUST_LABELS['ai-draft'];
 }
-
 function renderRuleBlock(title, info) {
   if (!info || !info.code) return '';
   const trust = ruleTrust(info);
   const licenseHtml = info.license
-    ? `<div class="rule-license">License: ${escapeHtml(info.license)} — 출처·author 고지 보존</div>`
-    : '';
-  return `
-    <div class="rule-block">
-      <div class="rule-header">
-        <span class="rule-title">${escapeHtml(title)}</span>
-        <span class="trust-badge ${trust.cls}">${trust.text}</span>
-        <span class="rule-source">${escapeHtml(info.source || '')}</span>
-        <button class="copy-btn" onclick="copyRule(this)" title="룰을 클립보드에 복사 — 보안 장비에 바로 등록">📋 복사</button>
-      </div>
-      ${licenseHtml}
-      <pre class="rule-preview">${escapeHtml(info.code)}</pre>
-    </div>`;
+    ? `<div class="rule-license">License: ${escapeHtml(info.license)} — 출처·author 고지 보존</div>` : '';
+  return `<div class="rule-block">
+    <div class="rule-header">
+      <span class="rule-title">${escapeHtml(title)}</span>
+      <span class="trust-badge ${trust.cls}">${trust.text}</span>
+      <span class="rule-source">${escapeHtml(info.source || '')}</span>
+      <button class="copy-btn" onclick="copyRule(this)" title="클립보드에 복사">📋 복사</button>
+    </div>
+    ${licenseHtml}
+    <pre class="rule-preview">${escapeHtml(info.code)}</pre>
+  </div>`;
 }
-
 function renderRulesSection(cve) {
   const rules = cve.rules || {};
-  let blocks = '';
-  blocks += renderRuleBlock('Sigma', rules.sigma);
-  (rules.network || []).forEach((r, i) => {
-    const engine = (r.engine || 'network').toUpperCase();
-    blocks += renderRuleBlock(`Network #${i + 1} (${engine})`, r);
-  });
+  let blocks = renderRuleBlock('Sigma', rules.sigma);
+  (rules.network || []).forEach((r, i) => { blocks += renderRuleBlock(`Network #${i + 1} (${(r.engine || 'network').toUpperCase()})`, r); });
   blocks += renderRuleBlock('YARA', rules.yara);
-
-  // 미생성 룰 불가 사유 (skip_reasons)
-  const skipLabels = { ai_generation: 'AI 룰 생성', sigma: 'Sigma', network: 'Snort/Suricata', yara: 'YARA' };
-  const skip = rules.skip_reasons || {};
-  const skipItems = Object.entries(skipLabels)
-    .filter(([k]) => skip[k])
-    .map(([k, label]) => `<div class="skip-item"><b>${escapeHtml(label)}</b>: ${escapeHtml(skip[k])}</div>`)
-    .join('');
-  const skipHtml = skipItems
-    ? `<div class="skip-reasons"><div class="skip-title">미생성 룰 사유</div>${skipItems}</div>`
-    : '';
-
-  if (!blocks && !skipHtml) {
-    return `
-      <div class="rules-section">
-        <h3>🛡️ 탐지 룰</h3>
-        <div class="detail-value" style="color:var(--text-muted);">수집·생성된 룰 없음</div>
-      </div>`;
+  if (!blocks) {
+    return `<div class="rules-section"><h3>🛡️ 공개 탐지 룰</h3><div class="no-rules">공개 룰셋(SigmaHQ / ET Open / Yara-Rules)에서 확인된 룰이 없습니다. 등록되면 자동 반영됩니다.</div></div>`;
   }
-  return `<div class="rules-section"><h3>🛡️ 탐지 룰</h3>${blocks}${skipHtml}</div>`;
+  return `<div class="rules-section"><h3>🛡️ 공개 탐지 룰</h3>${blocks}</div>`;
 }
-
 async function copyRule(btn) {
   const pre = btn.closest('.rule-block')?.querySelector('pre');
   if (!pre) return;
-  const text = pre.textContent;
-  try {
-    await navigator.clipboard.writeText(text);
-    flashBtn(btn, '✓ 복사됨');
-  } catch {
-    // 클립보드 API 미지원/거부 시 폴백
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.style.position = 'fixed';
-    ta.style.opacity = '0';
-    document.body.appendChild(ta);
-    ta.select();
-    try {
-      document.execCommand('copy');
-      flashBtn(btn, '✓ 복사됨');
-    } catch {
-      flashBtn(btn, '복사 실패');
-    }
+  try { await navigator.clipboard.writeText(pre.textContent); flashBtn(btn, '✓ 복사됨'); }
+  catch {
+    const ta = document.createElement('textarea'); ta.value = pre.textContent;
+    ta.style.cssText = 'position:fixed;opacity:0'; document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); flashBtn(btn, '✓ 복사됨'); } catch { flashBtn(btn, '복사 실패'); }
     ta.remove();
   }
 }
-
 function flashBtn(btn, msg) {
-  const orig = btn.textContent;
-  btn.textContent = msg;
-  btn.disabled = true;
+  const orig = btn.textContent; btn.textContent = msg; btn.disabled = true;
   setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 1500);
-}
-
-// ===== 위협 신호 상세 (모달) — 출처: Metasploit metadata는 BSD-3-Clause =====
-function renderThreatSignals(cve) {
-  const parts = [];
-  if (cve.ssvc_exploitation) {
-    parts.push(`CISA SSVC Exploitation: <b>${escapeHtml(cve.ssvc_exploitation)}</b> <span style="color:var(--text-muted)">(vulnrichment, CC0)</span>`);
-  }
-  if (cve.has_metasploit_module) {
-    const mods = (cve.metasploit_modules || []).map(m => escapeHtml(m)).join(', ');
-    parts.push(`Metasploit: <b>무기화됨</b>${mods ? ' — ' + mods : ''} <span style="color:var(--text-muted)">(Metasploit Framework, BSD-3)</span>`);
-  }
-  if (cve.has_public_exploit) {
-    parts.push(`ExploitDB: <b>공개 익스플로잇 존재</b>`);
-  }
-  if (!parts.length) return '';
-  return `
-    <div class="detail-row">
-      <span class="detail-label">위협 신호</span>
-      <span class="detail-value">${parts.map(p => `<div>${p}</div>`).join('')}</span>
-    </div>`;
 }
 
 // ===== 상세 모달 =====
 function showDetail(cveId) {
   const cve = allCves.find(c => c.id === cveId);
   if (!cve) return;
+  const sev = cve.severity || 'None';
 
-  document.getElementById('modal-title').textContent = cve.id;
+  const hero = document.getElementById('modal-hero');
+  hero.className = `modal-hero h-${sev}`;
+  document.getElementById('modal-id').textContent = cve.id;
+  document.getElementById('modal-sev-badge').innerHTML = `<span class="badge badge-sev sev-${sev}">${sev}</span>`;
+  document.getElementById('modal-signals').innerHTML = signalBadges(cve);
+  document.getElementById('modal-title').textContent = cve.title || 'N/A';
+  document.getElementById('modal-scores').innerHTML = `
+    <div class="mscore"><span class="lbl">CVSS</span><span class="vl" style="color:${sevColor(sev)}">${(cve.cvss || 0).toFixed(1)}</span></div>
+    <div class="mscore"><span class="lbl">EPSS (악용 확률)</span><span class="vl">${((cve.epss || 0) * 100).toFixed(2)}%</span></div>
+    <div class="mscore"><span class="lbl">CISA KEV</span><span class="vl" style="color:${cve.is_kev ? 'var(--sig-kev)' : 'var(--text-faint)'}">${cve.is_kev ? 'YES' : 'No'}</span></div>`;
 
-  const body = document.getElementById('modal-body');
-  const sevClass = `badge-${(cve.severity || 'none').toLowerCase()}`;
-  const affectedHtml = (cve.affected || []).map(a =>
-    `<div>${escapeHtml(a.vendor)} / ${escapeHtml(a.product)} (${escapeHtml(a.versions || '-')})</div>`
-  ).join('') || '<div>정보 없음</div>';
-
-  const cweHtml = (cve.cwe || []).join(', ') || 'N/A';
-
-  // 상세 리포트 배너 (AI 분석 전문·대응 방안은 GitHub Issue에 — 기존 설계 유지)
+  const affectedHtml = (cve.affected || []).length
+    ? (cve.affected || []).map(a => `<div class="affected-item"><b>${escapeHtml(a.vendor)}</b> / ${escapeHtml(a.product)} <span style="color:var(--text-faint)">(${escapeHtml(a.versions || '-')})</span></div>`).join('')
+    : '<span style="color:var(--text-faint)">정보 없음</span>';
+  const cweHtml = (cve.cwe || []).length ? (cve.cwe || []).map(c => `<span class="cwe-chip">${escapeHtml(c)}</span>`).join(' ') : '<span style="color:var(--text-faint)">N/A</span>';
   const reportBanner = isSafeUrl(cve.report_url)
-    ? `<a href="${escapeHtml(cve.report_url)}" target="_blank" rel="noopener noreferrer" class="report-link-primary">📋 AI 상세 분석 리포트 열기 (GitHub Issue) — 분석 전문 · 대응 방안 · 벡터 해석 →</a>`
-    : '';
+    ? `<a href="${escapeHtml(cve.report_url)}" target="_blank" rel="noopener noreferrer" class="report-link-primary">📋 AI 상세 분석 리포트 (GitHub Issue) — 근본원인 · 공격 시나리오 · 대응 방안 →</a>` : '';
 
-  body.innerHTML = `
+  document.getElementById('modal-body').innerHTML = `
     ${reportBanner}
-    <div class="detail-row">
-      <span class="detail-label">제목</span>
-      <span class="detail-value">${escapeHtml(cve.title || 'N/A')}</span>
+    <div class="detail-grid">
+      ${renderThreatSignals(cve)}
+      <div class="detail-row"><span class="detail-label">취약점 유형</span><span class="detail-value">${cweHtml}</span></div>
+      <div class="detail-row"><span class="detail-label">영향 자산</span><span class="detail-value">${affectedHtml}</span></div>
+      <div class="detail-row"><span class="detail-label">설명</span><span class="detail-value">${escapeHtml(cve.description || 'N/A')}</span></div>
     </div>
-    <div class="detail-row">
-      <span class="detail-label">심각도</span>
-      <span class="detail-value"><span class="badge ${sevClass}">${cve.severity}</span> CVSS ${(cve.cvss || 0).toFixed(1)} / EPSS ${((cve.epss || 0) * 100).toFixed(2)}%</span>
-    </div>
-    <div class="detail-row">
-      <span class="detail-label">KEV</span>
-      <span class="detail-value">${cve.is_kev ? 'YES' : 'No'}</span>
-    </div>
-    ${renderThreatSignals(cve)}
-    <div class="detail-row">
-      <span class="detail-label">CWE</span>
-      <span class="detail-value">${cweHtml}</span>
-    </div>
-    <div class="detail-row">
-      <span class="detail-label">영향 자산</span>
-      <span class="detail-value">${affectedHtml}</span>
-    </div>
-    <div class="detail-row">
-      <span class="detail-label">설명</span>
-      <span class="detail-value">${escapeHtml(cve.description || 'N/A')}</span>
-    </div>
-    ${renderRulesSection(cve)}
-  `;
+    ${renderRulesSection(cve)}`;
 
   document.getElementById('modal-overlay').classList.add('active');
+}
+
+function renderThreatSignals(cve) {
+  const parts = [];
+  if (cve.ssvc_exploitation) parts.push(`CISA SSVC: <b>${escapeHtml(cve.ssvc_exploitation)}</b> <span style="color:var(--text-faint)">(vulnrichment, CC0)</span>`);
+  if (cve.has_metasploit_module) {
+    const mods = (cve.metasploit_modules || []).map(escapeHtml).join(', ');
+    parts.push(`Metasploit: <b style="color:var(--sig-msf)">무기화됨</b>${mods ? ' — ' + mods : ''}`);
+  }
+  if (cve.has_public_exploit) parts.push(`ExploitDB: <b style="color:var(--sig-edb)">공개 익스플로잇 존재</b>`);
+  if (cve.has_poc) parts.push(`PoC: <b style="color:var(--sig-poc)">공개됨</b>`);
+  if (!parts.length) return '';
+  return `<div class="detail-row"><span class="detail-label">위협 신호</span><span class="detail-value">${parts.map(p => `<div>${p}</div>`).join('')}</span></div>`;
 }
 
 function closeModal() {
@@ -439,189 +375,107 @@ function closeModal() {
 
 // ===== 유틸 =====
 function escapeHtml(str) {
-  if (!str) return '';
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  if (str === null || str === undefined) return '';
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
-
 function isSafeUrl(url) {
   if (!url) return false;
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
-  } catch {
-    return false;
-  }
+  try { const p = new URL(url); return p.protocol === 'https:' || p.protocol === 'http:'; } catch { return false; }
 }
 
-// ===== 클라이언트 사이드 Export (CSV / JSON / STIX 2.1 — 서버 불필요) =====
+// ===== Export (CSV / JSON / STIX 2.1) =====
 function exportData(format) {
-  if (!filteredCves.length) {
-    alert('내보낼 데이터가 없습니다. (필터 조건을 확인하세요)');
-    return;
-  }
+  if (!filteredCves.length) { alert('내보낼 데이터가 없습니다. (필터 조건을 확인하세요)'); return; }
   const ts = new Date().toISOString().slice(0, 10);
-  if (format === 'csv') {
-    downloadBlob(toCsv(filteredCves), `argus-cves-${ts}.csv`, 'text/csv;charset=utf-8');
-  } else if (format === 'json') {
-    downloadBlob(JSON.stringify(filteredCves, null, 2), `argus-cves-${ts}.json`, 'application/json');
-  } else if (format === 'stix') {
-    downloadBlob(JSON.stringify(toStixBundle(filteredCves), null, 2), `argus-cves-stix-${ts}.json`, 'application/json');
-  }
+  if (format === 'csv') downloadBlob(toCsv(filteredCves), `argus-cves-${ts}.csv`, 'text/csv;charset=utf-8');
+  else if (format === 'json') downloadBlob(JSON.stringify(filteredCves, null, 2), `argus-cves-${ts}.json`, 'application/json');
+  else if (format === 'stix') downloadBlob(JSON.stringify(toStixBundle(filteredCves), null, 2), `argus-cves-stix-${ts}.json`, 'application/json');
 }
-
-// ===== 월별 고위험(Critical/High) CVE CSV — 심각도 토글과 무관하게 원클릭 다운로드 =====
 function exportHighRiskByMonth() {
-  const month = activeFilters.month; // '' = 전체 기간
-  const rows = allCves
-    .filter(c => (c.severity === 'Critical' || c.severity === 'High'))
-    .filter(c => !month || cveMonth(c) === month)
-    .sort((a, b) => (b.cvss || 0) - (a.cvss || 0));
-  if (!rows.length) {
-    alert(month ? `${month} 월의 고위험 CVE가 없습니다.` : '고위험 CVE가 없습니다.');
-    return;
-  }
-  const label = month || 'all';
-  downloadBlob(toCsv(rows), `argus-highrisk-${label}.csv`, 'text/csv;charset=utf-8');
+  const month = activeFilters.month;
+  const rows = allCves.filter(c => c.severity === 'Critical' || c.severity === 'High')
+    .filter(c => !month || cveMonth(c) === month).sort((a, b) => (b.cvss || 0) - (a.cvss || 0));
+  if (!rows.length) { alert(month ? `${month} 월의 고위험 CVE가 없습니다.` : '고위험 CVE가 없습니다.'); return; }
+  downloadBlob(toCsv(rows), `argus-highrisk-${month || 'all'}.csv`, 'text/csv;charset=utf-8');
 }
-
 function toCsv(cves) {
-  const esc = v => {
-    const s = String(v ?? '');
-    return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
-  };
+  const esc = v => { const s = String(v ?? ''); return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s; };
   const header = ['cve_id', 'title', 'severity', 'cvss', 'epss', 'kev', 'ssvc_exploitation', 'metasploit', 'public_exploit', 'vendor', 'product', 'rule_engines', 'date', 'report_url'];
   const lines = [header.join(',')];
-  for (const c of cves) {
-    lines.push([
-      c.id,
-      c.title || '',
-      c.severity || '',
-      c.cvss || 0,
-      c.epss || 0,
-      c.is_kev ? 'Y' : 'N',
-      c.ssvc_exploitation || '',
-      c.has_metasploit_module ? 'Y' : 'N',
-      c.has_public_exploit ? 'Y' : 'N',
-      c.affected?.[0]?.vendor || '',
-      c.affected?.[0]?.product || '',
-      (c.rule_engines || []).join(';'),
-      c.date || '',
-      c.report_url || '',
-    ].map(esc).join(','));
-  }
-  // BOM — Excel에서 한글 깨짐 방지
-  return '\uFEFF' + lines.join('\n');
+  for (const c of cves) lines.push([
+    c.id, c.title || '', c.severity || '', c.cvss || 0, c.epss || 0, c.is_kev ? 'Y' : 'N',
+    c.ssvc_exploitation || '', c.has_metasploit_module ? 'Y' : 'N', c.has_public_exploit ? 'Y' : 'N',
+    c.affected?.[0]?.vendor || '', c.affected?.[0]?.product || '', (c.rule_engines || []).join(';'),
+    c.date || '', c.report_url || '',
+  ].map(esc).join(','));
+  return '﻿' + lines.join('\n');
 }
-
 function toStixBundle(cves) {
   const now = new Date().toISOString();
-  const uuid = () => {
-    if (crypto.randomUUID) return crypto.randomUUID();
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-      const r = crypto.getRandomValues(new Uint8Array(1))[0] % 16;
-      const v = c === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
-  };
-
+  const uuid = () => (crypto.randomUUID ? crypto.randomUUID() : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = crypto.getRandomValues(new Uint8Array(1))[0] % 16; const v = c === 'x' ? r : (r & 0x3) | 0x8; return v.toString(16);
+  }));
   const objects = cves.map(c => {
-    // STIX 2.1 timestamp는 UTC 'Z' 형식 필수
-    let ts = now;
-    if (c.date) {
-      const d = new Date(c.date);
-      if (!isNaN(d)) ts = d.toISOString();
-    }
+    let ts = now; if (c.date) { const d = new Date(c.date); if (!isNaN(d)) ts = d.toISOString(); }
     const refs = [{ source_name: 'cve', external_id: c.id }];
-    if (isSafeUrl(c.report_url)) {
-      refs.push({ source_name: 'Argus AI Report', url: c.report_url });
-    }
+    if (isSafeUrl(c.report_url)) refs.push({ source_name: 'Argus AI Report', url: c.report_url });
     return {
-      type: 'vulnerability',
-      spec_version: '2.1',
-      id: 'vulnerability--' + uuid(),
-      created: ts,
-      modified: ts,
-      name: c.id,
-      description: [c.title, c.description].filter(Boolean).join(' — '),
-      external_references: refs,
-      x_severity: c.severity || 'None',
-      x_cvss_score: c.cvss || 0,
-      x_epss_score: c.epss || 0,
-      x_cisa_kev: !!c.is_kev,
-      x_ssvc_exploitation: c.ssvc_exploitation || null,
-      x_has_metasploit_module: !!c.has_metasploit_module,
-      x_has_public_exploit: !!c.has_public_exploit,
-      x_rule_engines: c.rule_engines || [],
+      type: 'vulnerability', spec_version: '2.1', id: 'vulnerability--' + uuid(), created: ts, modified: ts,
+      name: c.id, description: [c.title, c.description].filter(Boolean).join(' — '), external_references: refs,
+      x_severity: c.severity || 'None', x_cvss_score: c.cvss || 0, x_epss_score: c.epss || 0, x_cisa_kev: !!c.is_kev,
+      x_ssvc_exploitation: c.ssvc_exploitation || null, x_has_metasploit_module: !!c.has_metasploit_module,
+      x_has_public_exploit: !!c.has_public_exploit, x_rule_engines: c.rule_engines || [],
     };
   });
-
   return { type: 'bundle', id: 'bundle--' + uuid(), objects };
 }
-
 function downloadBlob(content, filename, mime) {
   const blob = new Blob([content], { type: mime });
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  const a = document.createElement('a'); a.href = url; a.download = filename;
+  document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
 }
 
 // ===== 이벤트 바인딩 =====
 document.addEventListener('DOMContentLoaded', () => {
   init();
 
-  // 검색
   const searchEl = document.getElementById('search-input');
   if (searchEl) {
     let timer;
     searchEl.addEventListener('input', () => {
       clearTimeout(timer);
-      timer = setTimeout(() => {
-        activeFilters.search = searchEl.value;
-        applyFilters();
-      }, 300);
+      timer = setTimeout(() => { activeFilters.search = searchEl.value; applyFilters(); }, 250);
     });
   }
 
-  // 벤더 필터
-  const vendorEl = document.getElementById('vendor-filter');
-  if (vendorEl) vendorEl.addEventListener('change', () => {
-    activeFilters.vendor = vendorEl.value;
-    applyFilters();
-  });
+  document.getElementById('vendor-filter')?.addEventListener('change', e => { activeFilters.vendor = e.target.value; applyFilters(); });
+  document.getElementById('month-filter')?.addEventListener('change', e => { activeFilters.month = e.target.value; applyFilters(); });
 
-  // 월별 필터
-  const monthEl = document.getElementById('month-filter');
-  if (monthEl) monthEl.addEventListener('change', () => {
-    activeFilters.month = monthEl.value;
+  // 심각도 세그먼트
+  document.querySelectorAll('.seg-btn').forEach(btn => btn.addEventListener('click', () => {
+    const sev = btn.dataset.severity;
+    if (activeFilters.severity.has(sev)) { activeFilters.severity.delete(sev); btn.classList.remove('active'); }
+    else { activeFilters.severity.add(sev); btn.classList.add('active'); }
     applyFilters();
-  });
+  }));
 
-  // 심각도 필터 버튼
-  document.querySelectorAll('.severity-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const sev = btn.dataset.severity;
-      if (activeFilters.severity.has(sev)) {
-        activeFilters.severity.delete(sev);
-        btn.classList.remove('active');
-      } else {
-        activeFilters.severity.add(sev);
-        btn.classList.add('active');
-      }
-      applyFilters();
-    });
-  });
+  // 위협 신호 토글
+  document.querySelectorAll('.signal-toggle').forEach(btn => btn.addEventListener('click', () => {
+    const sig = btn.dataset.signal;
+    if (activeFilters.signals.has(sig)) { activeFilters.signals.delete(sig); btn.classList.remove('active'); }
+    else { activeFilters.signals.add(sig); btn.classList.add('active'); }
+    applyFilters();
+  }));
+
+  // 정렬 헤더
+  document.querySelectorAll('th.sortable').forEach(th => th.addEventListener('click', () => sortBy(th.dataset.sort)));
 
   // 모달 닫기
-  document.getElementById('modal-overlay')?.addEventListener('click', (e) => {
-    if (e.target === e.currentTarget) closeModal();
-  });
+  document.getElementById('modal-overlay')?.addEventListener('click', e => { if (e.target === e.currentTarget) closeModal(); });
+  document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
 
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closeModal();
-  });
+  // 리사이즈 시 차트 다시 그리기
+  let rt;
+  window.addEventListener('resize', () => { clearTimeout(rt); rt = setTimeout(renderChart, 200); });
 });


### PR DESCRIPTION
낡은 구성을 취약점 분석에 최적화된 현대적 다크 대시보드로 재설계:
- 불필요한 CVE nav 탭 제거 (단일 페이지) → 로고 + 실시간 수집 상태만
- 위협 중심 KPI 스트립: 전체 / Critical / 실제 악용(KEV) / 무기화(MSF·EDB) / High — 좌측 컬러 액센트로 위험도 즉시 식별
- 위협 신호 필터 추가(악용 중 · 무기화 · PoC) — 실제 대응 대상을 원클릭 필터
- 심각도 세그먼트 컨트롤(색상 코딩) + 큰 검색창(제품·벤더까지 검색)
- 테이블: 행 좌측 심각도 컬러바 + 배지 + CVSS 게이지 + EPSS + 위협 신호 배지
- 상세 모달: 심각도 히어로(CVSS/EPSS/KEV 점수) + CWE 칩 + 영향 자산 + 공개 룰
- 차트: CSS 변수 연동 막대 + 호버 툴팁, 심각도/벤더 분포 바
- 디자인 시스템: 그라디언트 배경, 일관된 spacing/radius, 라이트모드 지원(prefers)
- 색상: severity=status 색(라벨 항상 동반, dataviz 검증 CVD ΔE 9.1), 신호=구분 hue

데이터 파이프라인·필드 무변경(순수 프론트). 브라우저 렌더링 검증(다크/모달) 완료.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd