### PR TITLE
fix(dashboard): 필터 바 2줄 재배치 + 헤더 겹침 해소 + 방패 아이콘 교체

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -136,10 +136,11 @@ main { padding: 28px 0 64px; }
 
 /* ---------- Filter bar ---------- */
 .filter-bar {
-  display: flex; flex-wrap: wrap; gap: 10px; align-items: center; background: var(--surface);
-  border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 14px; margin-bottom: 16px; box-shadow: var(--shadow);
+  display: flex; flex-direction: column; gap: 11px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 13px 14px; margin-bottom: 16px; box-shadow: var(--shadow);
 }
-.search-wrap { position: relative; flex: 1 1 280px; min-width: 220px; }
+.filter-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.search-wrap { position: relative; flex: 1 1 auto; min-width: 220px; }
 .search-wrap svg { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--text-faint); pointer-events: none; }
 .search-input {
   width: 100%; padding: 10px 12px 10px 36px; background: var(--surface-2); border: 1px solid var(--border);
@@ -160,11 +161,10 @@ main { padding: 28px 0 64px; }
 .seg-btn.active.sev-c-medium { color: var(--sev-medium); }
 .seg-btn.active.sev-c-low { color: var(--sev-low); }
 
-.signal-toggle { padding: 7px 12px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text-muted); font-size: 12px; font-weight: 600; font-family: inherit; border-radius: 999px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; transition: all .12s; }
-.signal-toggle:hover { border-color: var(--border-strong); color: var(--text); }
-.signal-toggle.active { background: color-mix(in srgb, var(--sig-kev) 16%, var(--surface)); border-color: var(--sig-kev); color: var(--sig-kev); }
-.signal-toggle.active[data-signal="weaponized"] { background: color-mix(in srgb, var(--sig-msf) 16%, var(--surface)); border-color: var(--sig-msf); color: var(--sig-msf); }
-.signal-toggle.active[data-signal="poc"] { background: color-mix(in srgb, var(--sig-poc) 16%, var(--surface)); border-color: var(--sig-poc); color: var(--sig-poc); }
+/* 위협 신호 토글 — 심각도 세그먼트와 동일한 사각형 pill 스타일 */
+.seg-btn.signal.active[data-signal="kev"] { color: var(--sig-kev); }
+.seg-btn.signal.active[data-signal="weaponized"] { color: var(--sig-msf); }
+.seg-btn.signal.active[data-signal="poc"] { color: var(--sig-poc); }
 
 .filter-spacer { flex: 1; }
 .export-group { display: inline-flex; gap: 6px; }
@@ -180,7 +180,7 @@ table { width: 100%; border-collapse: collapse; min-width: 820px; }
 thead th {
   text-align: left; padding: 13px 14px; font-size: 11px; font-weight: 700; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: .04em; background: var(--surface-2); border-bottom: 1px solid var(--border);
-  position: sticky; top: 62px; z-index: 5; white-space: nowrap;
+  white-space: nowrap;
 }
 thead th.sortable { cursor: pointer; user-select: none; }
 thead th.sortable:hover { color: var(--text); }

--- a/docs/cve.html
+++ b/docs/cve.html
@@ -5,14 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Argus · CVE Threat Dashboard</title>
   <meta name="description" content="CVE 취약점 위협 인텔리전스 대시보드 — 실제 악용·무기화·고위험 취약점을 한눈에.">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%231f6feb' d='M12 2 4 5v6c0 5 3.4 9.7 8 11 4.6-1.3 8-6 8-11V5z'/%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%231f6feb' d='M12 1.5 3.5 5v6.2c0 5.4 3.6 10.4 8.5 11.8 4.9-1.4 8.5-6.4 8.5-11.8V5z'/%3E%3Cpath fill='none' stroke='%23fff' stroke-width='2.3' stroke-linecap='round' stroke-linejoin='round' d='m8.3 12 2.5 2.5 4.9-5'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header class="header">
     <div class="container header-inner">
       <a href="cve.html" class="logo">
-        <span class="logo-badge">&#128737;</span>
+        <span class="logo-badge">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
+        </span>
         <span>Argus<small>CVE Threat Intelligence</small></span>
       </a>
       <div class="header-spacer"></div>
@@ -69,31 +71,37 @@
 
     <!-- Filter bar -->
     <section class="filter-bar">
-      <div class="search-wrap">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-        <input type="text" class="search-input" id="search-input" placeholder="CVE ID · 제품 · 키워드 검색…">
+      <!-- 위쪽: 검색 + 벤더 + 기간 -->
+      <div class="filter-row">
+        <div class="search-wrap">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          <input type="text" class="search-input" id="search-input" placeholder="CVE ID · 제품 · 벤더 · 키워드 검색…">
+        </div>
+        <select class="filter-select" id="vendor-filter"><option value="">전체 벤더</option></select>
+        <select class="filter-select" id="month-filter" title="월별 필터"><option value="">전체 기간</option></select>
       </div>
 
-      <div class="seg" id="severity-seg">
-        <button class="seg-btn active sev-c-critical" data-severity="Critical"><span class="dot" style="background:var(--sev-critical)"></span>Critical</button>
-        <button class="seg-btn active sev-c-high" data-severity="High"><span class="dot" style="background:var(--sev-high)"></span>High</button>
-        <button class="seg-btn active sev-c-medium" data-severity="Medium"><span class="dot" style="background:var(--sev-medium)"></span>Medium</button>
-        <button class="seg-btn active sev-c-low" data-severity="Low"><span class="dot" style="background:var(--sev-low)"></span>Low</button>
-      </div>
+      <!-- 아래: 심각도 + 위협신호(좌) / 다운로드(우) -->
+      <div class="filter-row">
+        <div class="seg" id="severity-seg">
+          <button class="seg-btn active sev-c-critical" data-severity="Critical"><span class="dot" style="background:var(--sev-critical)"></span>Critical</button>
+          <button class="seg-btn active sev-c-high" data-severity="High"><span class="dot" style="background:var(--sev-high)"></span>High</button>
+          <button class="seg-btn active sev-c-medium" data-severity="Medium"><span class="dot" style="background:var(--sev-medium)"></span>Medium</button>
+          <button class="seg-btn active sev-c-low" data-severity="Low"><span class="dot" style="background:var(--sev-low)"></span>Low</button>
+        </div>
+        <div class="seg">
+          <button class="seg-btn signal" data-signal="kev">🚨 악용 중</button>
+          <button class="seg-btn signal" data-signal="weaponized">🧨 무기화</button>
+          <button class="seg-btn signal" data-signal="poc">🔬 PoC</button>
+        </div>
 
-      <button class="signal-toggle" data-signal="kev">🚨 악용 중</button>
-      <button class="signal-toggle" data-signal="weaponized">🧨 무기화</button>
-      <button class="signal-toggle" data-signal="poc">🔬 PoC</button>
-
-      <select class="filter-select" id="vendor-filter"><option value="">전체 벤더</option></select>
-      <select class="filter-select" id="month-filter" title="월별 필터"><option value="">전체 기간</option></select>
-
-      <div class="filter-spacer"></div>
-      <div class="export-group">
-        <button class="export-btn export-highrisk" onclick="exportHighRiskByMonth()" title="선택 월의 고위험(Critical/High)을 CSV로">고위험 CSV ↓</button>
-        <button class="export-btn" onclick="exportData('csv')" title="필터된 목록 CSV">CSV</button>
-        <button class="export-btn" onclick="exportData('json')" title="필터된 목록 JSON">JSON</button>
-        <button class="export-btn" onclick="exportData('stix')" title="필터된 목록 STIX 2.1">STIX</button>
+        <div class="filter-spacer"></div>
+        <div class="export-group">
+          <button class="export-btn export-highrisk" onclick="exportHighRiskByMonth()" title="선택 월의 고위험(Critical/High)을 CSV로">고위험 CVE ↓</button>
+          <button class="export-btn" onclick="exportData('csv')" title="필터된 목록 CSV">CSV ↓</button>
+          <button class="export-btn" onclick="exportData('json')" title="필터된 목록 JSON">JSON ↓</button>
+          <button class="export-btn" onclick="exportData('stix')" title="필터된 목록 STIX 2.1">STIX ↓</button>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
사용자 피드백 반영:
- 테이블 thead sticky(top:62px)가 overflow 컨테이너 안에서 첫 데이터 행을 침범 → sticky 제거(41건·페이지 50건이라 고정 불필요, 겹침이 더 큰 문제)
- 로고/favicon: 튤립처럼 보이던 방패 → 체크마크 방패(shield-check)로 교체
- 필터 바 2줄 분리: · 위쪽: 검색창(폭 확장) + 벤더 + 기간 · 아래쪽: 심각도 세그먼트 + 위협신호(악용중·무기화·PoC)를 좌측에, 다운로드 버튼(우측 정렬)
- 위협신호 토글: 동그라미(pill) → 심각도와 동일한 사각 세그먼트로 통일
- '고위험 CSV' → '고위험 CVE'로 이름 변경 (↓ 유지)

브라우저 렌더링 검증 완료.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd