### PR TITLE
fix(dashboard): 위협신호 필터 이벤트 바인딩 복구

### DIFF
--- a/docs/js/cve-dashboard.js
+++ b/docs/js/cve-dashboard.js
@@ -452,16 +452,16 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('vendor-filter')?.addEventListener('change', e => { activeFilters.vendor = e.target.value; applyFilters(); });
   document.getElementById('month-filter')?.addEventListener('change', e => { activeFilters.month = e.target.value; applyFilters(); });
 
-  // 심각도 세그먼트
-  document.querySelectorAll('.seg-btn').forEach(btn => btn.addEventListener('click', () => {
+  // 심각도 세그먼트 (data-severity 있는 버튼만 — 신호 버튼과 분리)
+  document.querySelectorAll('.seg-btn[data-severity]').forEach(btn => btn.addEventListener('click', () => {
     const sev = btn.dataset.severity;
     if (activeFilters.severity.has(sev)) { activeFilters.severity.delete(sev); btn.classList.remove('active'); }
     else { activeFilters.severity.add(sev); btn.classList.add('active'); }
     applyFilters();
   }));
 
-  // 위협 신호 토글
-  document.querySelectorAll('.signal-toggle').forEach(btn => btn.addEventListener('click', () => {
+  // 위협 신호 토글 (사각 세그먼트 .seg-btn.signal)
+  document.querySelectorAll('.seg-btn.signal').forEach(btn => btn.addEventListener('click', () => {
     const sig = btn.dataset.signal;
     if (activeFilters.signals.has(sig)) { activeFilters.signals.delete(sig); btn.classList.remove('active'); }
     else { activeFilters.signals.add(sig); btn.classList.add('active'); }


### PR DESCRIPTION
필터 바 재배치 때 신호 버튼 클래스를 .signal-toggle → .seg-btn.signal로 바꿨으나 이벤트 바인딩이 옛 셀렉터(.signal-toggle)를 찾아 리스너가 안 붙었다. 게다가 신호 버튼도 .seg-btn이라 심각도 리스너에 걸려 active만 토글되고
(눌리는 것처럼 보임) activeFilters.signals에는 반영되지 않았다.

수정:
- 심각도 리스너: .seg-btn → .seg-btn[data-severity] (신호 버튼 제외)
- 신호 리스너: .signal-toggle → .seg-btn.signal

검증: KEV=16건, KEV+PoC=8건(AND 교집합), 해제 시 전체 복귀, 심각도 필터 정상.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd