### PR TITLE
fix: DB 저장 실패 원인 노출·2차 재시도 + 대시보드 공개 룰 배지·필터

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -31,6 +31,7 @@
   --sig-msf: #c084fc;
   --sig-edb: #f0883e;
   --sig-poc: #22d3ee;
+  --sig-rules: #3fb950; /* 공개 탐지 룰 — 방어 수단 존재(녹색). 위협 신호와 색상군 분리 */
 
   --radius: 12px;
   --radius-sm: 8px;
@@ -165,6 +166,7 @@ main { padding: 28px 0 64px; }
 .seg-btn.signal.active[data-signal="kev"] { color: var(--sig-kev); }
 .seg-btn.signal.active[data-signal="weaponized"] { color: var(--sig-msf); }
 .seg-btn.signal.active[data-signal="poc"] { color: var(--sig-poc); }
+.seg-btn.signal.active[data-signal="rules"] { color: var(--sig-rules); }
 
 .filter-spacer { flex: 1; }
 .export-group { display: inline-flex; gap: 6px; }
@@ -228,6 +230,7 @@ tr[data-severity="None"] td.cell-sev::before { background: var(--sev-none); }
 .badge-edb { background: color-mix(in srgb, var(--sig-edb) 20%, transparent); color: var(--sig-edb); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-edb) 40%, transparent); }
 .badge-poc { background: color-mix(in srgb, var(--sig-poc) 18%, transparent); color: var(--sig-poc); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-poc) 38%, transparent); }
 .badge-ssvc { background: color-mix(in srgb, var(--sig-kev) 20%, transparent); color: var(--sig-kev); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-kev) 40%, transparent); }
+.badge-rules { background: color-mix(in srgb, var(--sig-rules) 18%, transparent); color: var(--sig-rules); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-rules) 38%, transparent); }
 
 /* ---------- Pagination ---------- */
 .pagination { display: flex; align-items: center; justify-content: center; gap: 14px; margin-top: 20px; }

--- a/docs/cve.html
+++ b/docs/cve.html
@@ -93,6 +93,7 @@
           <button class="seg-btn signal" data-signal="kev">🚨 악용 중</button>
           <button class="seg-btn signal" data-signal="weaponized">🧨 무기화</button>
           <button class="seg-btn signal" data-signal="poc">🔬 PoC</button>
+          <button class="seg-btn signal" data-signal="rules">🛡️ 공개 룰</button>
         </div>
 
         <div class="filter-spacer"></div>

--- a/docs/js/cve-dashboard.js
+++ b/docs/js/cve-dashboard.js
@@ -147,7 +147,12 @@ function cveHasSignal(cve, sig) {
   if (sig === 'kev') return cve.is_kev || cve.ssvc_exploitation === 'active';
   if (sig === 'weaponized') return cve.has_metasploit_module || cve.has_public_exploit;
   if (sig === 'poc') return cve.has_poc;
+  if (sig === 'rules') return cveHasRules(cve);
   return true;
+}
+
+function cveHasRules(cve) {
+  return (cve.rule_engines || []).length > 0 || !!cve.has_official_rules;
 }
 
 function applyFilters() {
@@ -231,6 +236,10 @@ function signalBadges(cve) {
   if (cve.has_metasploit_module) out += '<span class="badge badge-msf" title="Metasploit 모듈 — 무기화됨">MSF</span>';
   if (cve.has_public_exploit) out += '<span class="badge badge-edb" title="ExploitDB 공개 익스플로잇">EDB</span>';
   if (cve.has_poc) out += '<span class="badge badge-poc" title="PoC 공개됨">PoC</span>';
+  if (cveHasRules(cve)) {
+    const engines = (cve.rule_engines || []).join(', ');
+    out += `<span class="badge badge-rules" title="공개 탐지 룰 존재${engines ? ' — ' + engines : ''} (상세에서 룰 원문 확인)">룰</span>`;
+  }
   return out;
 }
 

--- a/src/database.py
+++ b/src/database.py
@@ -1,9 +1,29 @@
 import os
+import time
 import datetime
 from supabase import create_client, Client
 from typing import Dict, List, Optional
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
 from logger import logger
+
+
+def _describe_error(e: BaseException) -> str:
+    """tenacity RetryError를 언랩해 실제 원인(APIError 등)의 메시지를 돌려준다.
+
+    RetryError 그대로 로깅하면 'RetryError[<Future ...>]'만 남아 원인(스키마 오류인지
+    일시 장애인지)을 알 수 없다 — 진단 가능한 로그가 되도록 반드시 언랩한다."""
+    if isinstance(e, RetryError):
+        try:
+            e = e.last_attempt.exception() or e
+        except Exception:
+            pass
+    msg = f"{type(e).__name__}: {e}"
+    # postgrest.APIError는 message/code/details/hint에 상세가 있다 (str에 빠질 수 있음)
+    for attr in ("message", "code", "details", "hint"):
+        v = getattr(e, attr, None)
+        if v and str(v) not in msg:
+            msg += f" | {attr}={v}"
+    return msg
 
 class DatabaseError(Exception):
     """데이터베이스 관련 에러"""
@@ -48,12 +68,23 @@ class ArgusDB:
             return None
 
     def upsert_cve(self, data: Dict) -> bool:
+        # 저장 실패 = Issue는 나갔는데 대시보드 영구 미반영 + 다음 실행 중복 재처리로 직결
+        # → 짧은 백오프(_execute, ~14초)를 넘기는 Supabase 일시 장애(풀 재시작 등)에 대비해
+        #   긴 간격 2차 시도까지 한다. (관측: 정상 레코드 2건이 동시각 APIError → 일시 장애)
         try:
             self._execute(self.client.table("cves").upsert(data))
             logger.debug(f"CVE 저장 성공: {data.get('id')}")
             return True
         except Exception as e:
-            logger.error(f"CVE 저장 실패 ({data.get('id')}): {e}")
+            logger.warning(f"CVE 저장 1차 실패 ({data.get('id')}): {_describe_error(e)} → 25초 후 재시도")
+        time.sleep(25)
+        try:
+            self._execute(self.client.table("cves").upsert(data))
+            logger.info(f"CVE 저장 재시도 성공: {data.get('id')}")
+            return True
+        except Exception as e:
+            # 최종 실패 → 호출측(finalize)이 failed 처리 → 워터마크가 붙잡아 다음 실행 재처리
+            logger.error(f"CVE 저장 실패 ({data.get('id')}): {_describe_error(e)}")
             return False
     
     def get_rule_recheck_candidates(self) -> List[Dict]:


### PR DESCRIPTION
[DB 저장 실패 (RetryError[APIError])]
실패한 두 레코드(54293/12701)를 원문 검사 — 널바이트·제어문자·크기 모두 정상. 동시각 연속 실패 = Supabase 일시 장애가 짧은 백오프(3회 ~14초)를 넘긴 케이스.
- RetryError 언랩(_describe_error): 실제 APIError message/code/details/hint를 로그에 노출 — 'RetryError[<Future ...>]'로는 스키마 오류/일시 장애 구분 불가했음
- upsert_cve: 1차 실패 시 25초 후 2차 시도 — 장애 창을 넘겨 저장 성공률 확보. 최종 실패는 기존대로 failed → 워터마크가 붙잡아 다음 실행 재처리(누락 없음)

[대시보드 공개 룰]
- 위협 신호 컬럼에 '룰' 배지(녹색 --sig-rules, 방어 신호로 색상군 분리, title에 엔진 목록) — 목록·모달 공통
- 필터 행에 '🛡️ 공개 룰' 시그널 버튼 추가 (기존 악용중/무기화/PoC와 동일 동작, rule_engines 또는 has_official_rules 보유 기준)

검증: RetryError 언랩/2차 재시도/최종 실패 스텁 + 브라우저 E2E(필터 27건 = 데이터 룰 보유 27건 일치, 배지 렌더, 복합 필터, title 엔진 노출).


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd