### PR TITLE
fix: affected의 vendor/product가 null일 때 자산 매칭이 크래시하던 버그 + 미사용 파라미터 5개 제거

### DIFF
--- a/src/collector.py
+++ b/src/collector.py
@@ -395,8 +395,12 @@ class Collector:
         results = []
         
         for item in affected_list:
-            vendor = item.get('vendor', 'Unknown')
-            product = item.get('product', 'Unknown')
+            # cvelistV5에는 "vendor": null 처럼 값이 명시적 null인 레코드가 있다.
+            # dict.get(k, 기본값)은 '키가 없을 때'만 기본값을 주므로 None이 그대로 흘러가,
+            # 자산 매칭(_norm/.lower())에서 AttributeError로 그 CVE가 매번 실패한다.
+            # → 여기서 문자열로 정규화해 모든 소비자(매칭·리포트·대시보드)를 한 번에 보호.
+            vendor = item.get('vendor') or 'Unknown'
+            product = item.get('product') or 'Unknown'
             versions = []
             patch_version = None
             
@@ -837,9 +841,9 @@ class Collector:
         cpes = cve_data.get('nvd_cpe') or []
         if not cpes:
             return cve_data
-        existing = cve_data.get('affected', [])
+        existing = cve_data.get('affected') or []
         has_valid_vendor = any(
-            (a.get('vendor', '').lower() not in ('', 'unknown', 'n/a')) for a in existing
+            str(a.get('vendor') or '').lower() not in ('', 'unknown', 'n/a') for a in existing
         )
         if has_valid_vendor:
             return cve_data  # CVE 자체 데이터 우선

--- a/src/export_dashboard_data.py
+++ b/src/export_dashboard_data.py
@@ -324,7 +324,7 @@ def main():
     # 주간 리포트 (직전 ISO 주가 아직 발행되지 않았을 때만)
     print("[3/4] 주간 리포트 확인...", flush=True)
     try:
-        publish_weekly_report(cve_data, stats)
+        publish_weekly_report(cve_data)
     except Exception as e:
         print(f"  [!] 주간 리포트 생성 실패(무시): {e}", flush=True)
 

--- a/src/main.py
+++ b/src/main.py
@@ -126,7 +126,7 @@ def parse_cvss_vector(vector_str: str) -> str:
     
     return "<br>".join(mapped_parts)
 
-def is_target_asset(cve_data: Dict, cve_id: str) -> Tuple[bool, Optional[str], Optional[str]]:
+def is_target_asset(cve_data: Dict) -> Tuple[bool, Optional[str], Optional[str]]:
     """자산 매칭 판정. 반환: (매칭 여부, 매칭 근거, 매칭 종류).
 
     매칭 종류(match_type)가 자산 기준 티어링의 핵심이다:
@@ -135,9 +135,10 @@ def is_target_asset(cve_data: Dict, cve_id: str) -> Tuple[bool, Optional[str], O
                    신규 저위험은 마커만 저장(대시보드 비노출)
       None       — 어느 룰에도 안 맞음 → 처리 안 함
     구체 룰을 전부 먼저 검사하고, 실패했을 때만 wildcard로 분류한다."""
-    # 벤더/제품 표기 차이(언더스코어 vs 공백)를 흡수해 매칭 누락 방지
-    def _norm(s: str) -> str:
-        return s.lower().replace('_', ' ').strip()
+    # 벤더/제품 표기 차이(언더스코어 vs 공백)를 흡수해 매칭 누락 방지.
+    # None 허용 — 레코드/DB 상태에 null이 섞여도 매칭이 죽지 않아야 한다.
+    def _norm(s) -> str:
+        return str(s or '').lower().replace('_', ' ').strip()
 
     has_wildcard = False
     for target in config.get_target_assets():
@@ -179,7 +180,7 @@ def is_target_asset(cve_data: Dict, cve_id: str) -> Tuple[bool, Optional[str], O
                 return True, f"Matched (NVD CPE): {c_vendor}/{c_product}", "asset"
 
         # 3차(보조): description 텍스트 매칭
-        desc_lower = cve_data.get('description', '').lower()
+        desc_lower = str(cve_data.get('description') or '').lower()
         if desc_lower and t_vendor in desc_lower and (t_product == "*" or t_product in desc_lower):
             return True, f"Matched (description): {t_vendor}/{t_product}", "asset"
 
@@ -327,8 +328,8 @@ def _needs_cpe_for_matching(cve_data: Dict) -> bool:
     if any(t.get('vendor') == '*' and t.get('product') == '*' for t in targets):
         return False
     return not any(
-        a.get('vendor', '').lower() not in ('', 'unknown', 'n/a')
-        for a in cve_data.get('affected', [])
+        str(a.get('vendor') or '').lower() not in ('', 'unknown', 'n/a')
+        for a in (cve_data.get('affected') or [])
     )
 
 def generate_korean_summary(cve_data: Dict, retry_on_transient: bool = False) -> Tuple[str, str]:
@@ -641,7 +642,7 @@ def create_github_issue(cve_data: Dict, reason: str) -> Tuple[Optional[str], Opt
         ])
         
         # Step 4: 마크다운 리포트 구성
-        body = _build_issue_body(cve_data, reason, analysis, rules, has_official)
+        body = _build_issue_body(cve_data, reason, analysis, rules)
         
         # Step 5: GitHub API 호출
         url = f"https://api.github.com/repos/{repo}/issues"
@@ -667,7 +668,7 @@ def create_github_issue(cve_data: Dict, reason: str) -> Tuple[Optional[str], Opt
         logger.error(f"GitHub Issue 생성 실패: {e}")
         return None, None
 
-def _build_issue_body(cve_data: Dict, reason: str, analysis: Dict, rules: Dict, has_official: bool) -> str:
+def _build_issue_body(cve_data: Dict, reason: str, analysis: Dict, rules: Dict) -> str:
     # CVSS 배지 색상
     score = cve_data['cvss']
     if score >= 9.0: color = "FF0000"
@@ -917,7 +918,7 @@ def prepare_single_cve(cve_id: str, collector: Collector, db: ArgusDB) -> Dict:
         # 소스를 확보한다(자산 매칭 누락 방지). 전체 감시(*/*)에서는 호출 안 함(비용 0).
         if _needs_cpe_for_matching(raw_data):
             collector.enrich_from_nvd(raw_data)
-        is_target, match_info, match_type = is_target_asset(raw_data, cve_id)
+        is_target, match_info, match_type = is_target_asset(raw_data)
         if not is_target:
             logger.debug(f"{cve_id}: 감시 대상 아님, 건너뜀")
             return {"cve_id": cve_id, "status": "handled", "stage": "done"}
@@ -1021,7 +1022,7 @@ def prepare_single_cve(cve_id: str, collector: Collector, db: ArgusDB) -> Dict:
 
 
 def finalize_single_cve(prep: Dict, translation: Optional[Tuple[str, str]],
-                        collector: Collector, db: ArgusDB, notifier: SlackNotifier) -> Dict:
+                        db: ArgusDB, notifier: SlackNotifier) -> Dict:
     """Phase C — 번역 결과 반영 후 Issue/Slack/DB 저장. prep은 prepare_single_cve의 ready 반환값.
 
     translation이 None이면(배치 번역 실패 등) 영문 폴백 — 기존 단건 번역 실패 폴백과 동일 정책."""
@@ -1106,7 +1107,7 @@ def process_single_cve(cve_id: str, collector: Collector, db: ArgusDB, notifier:
     if prep.get("stage") != "ready":
         return {"cve_id": cve_id, "status": prep.get("status", "failed")}
     translation = generate_korean_summary(prep["current_state"], retry_on_transient=prep["should_alert"])
-    return finalize_single_cve(prep, translation, collector, db, notifier)
+    return finalize_single_cve(prep, translation, db, notifier)
 
 def _risk_tier(current: Dict) -> str:
     """위험 3단 티어. 실무 유입에서 CVSS 7점대는 하루 수백 건(CISA ADP가 무점수 CVE에
@@ -1543,7 +1544,7 @@ def _main():
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
                 executor.submit(finalize_single_cve, p, translations.get(p["cve_id"]),
-                                collector, db, notifier): p["cve_id"]
+                                db, notifier): p["cve_id"]
                 for p in prepared
             }
             for future in as_completed(futures):

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -79,7 +79,7 @@ class SlackNotifier:
         if urgent is None:
             urgent = self.is_urgent(cve_data)
         if urgent:
-            self._send_urgent_alert(cve_data, reason, report_url)
+            self._send_urgent_alert(cve_data, report_url)
 
         return True
 
@@ -95,7 +95,7 @@ class SlackNotifier:
             or (cve_data.get('cvss') or 0) >= 9.0
         )
 
-    def _send_urgent_alert(self, cve_data: Dict, reason: str, report_url: Optional[str] = None) -> bool:
+    def _send_urgent_alert(self, cve_data: Dict, report_url: Optional[str] = None) -> bool:
         """긴급 CVE 즉시 알림 (실제 악용·무기화 신호 또는 CVSS 9+)"""
         try:
             display_title = cve_data.get('title_ko', cve_data.get('title', 'N/A'))

--- a/src/weekly_report.py
+++ b/src/weekly_report.py
@@ -142,7 +142,7 @@ def build_weekly_body(week_cves: List[Dict], week_label: str,
     return "\n".join(lines)
 
 
-def publish_weekly_report(cve_data: List[Dict], stats: Dict,
+def publish_weekly_report(cve_data: List[Dict],
                           repo: Optional[str] = None, token: Optional[str] = None) -> Optional[str]:
     """직전 주 리포트를 GitHub Issue로 발행. 이미 있으면 건너뛴다. 반환: 이슈 URL 또는 None."""
     repo = repo or os.environ.get("GITHUB_REPOSITORY", "")


### PR DESCRIPTION
[버그] 자산을 등록하는 순간 터지는 매칭 크래시 — 현재는 와일드카드에 가려져 잠복
cvelistV5에는 "vendor": null 인 레코드가 존재한다. parse_affected가 item.get('vendor', 'Unknown')을 쓰는데 dict.get의 기본값은 '키가 없을 때'만 적용되므로 None이 그대로 통과하고, 이후 _norm()/.lower()에서 AttributeError. 지금은 assets.json이 */* 라 단축 평가로 우회되지만, 구체 자산을 등록하면
(이 프로젝트의 핵심 사용 시나리오) 해당 CVE가 매 실행 실패한다.
  · _needs_cpe_for_matching / is_target_asset 둘 다 크래시 재현 확인
→ parse_affected에서 문자열로 정규화(근본 수정) + _norm·소비자 3곳 None 방어
  (DB에 이미 저장된 과거 상태로 들어오는 경로까지 커버)

[데드코드] 호출부에서 값을 넘기지만 본문에서 전혀 안 쓰는 파라미터 5개 제거
  is_target_asset(cve_id) · _build_issue_body(has_official) ·
  finalize_single_cve(collector) · _send_urgent_alert(reason) ·
  publish_weekly_report(stats)  — 호출부까지 함께 정리

검수 범위(카테고리 고정, 전 항목 통과):
  A 정적: 컴파일·미사용 import 0·미사용 파라미터 0·데드 함수 0
  B 런타임: None/인덱스/0나눗셈 패턴 전수 점검 — 잔여 위험 없음
  C 데이터계약: export 출력 키 ↔ JS 소비 키 런타임 대조 일치(양방향 0)
  D 논리일관성: _risk_tier·is_urgent·_priority_banner·_issue_labels 9케이스 일치
  E 동시성: 워커 공유 상태 4종 모두 read-only 또는 락 보호
  F 자원한도: 상한 없는 DB 조회 0, export 페이지네이션 정상
  G 예외처리: 광범위 except 3곳 모두 의도된 best-effort 경로
  H 통합: 워크플로 env ↔ 코드 요구 일치(NVD/VulnCheck 키는 선택적·우아한 생략)
  I 회귀: 스텁 9종 + 브라우저 E2E 2종 전부 통과


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd