### PR TITLE
fix: 제품만 등록(*/product) 시 벤더 불명 CVE가 매칭되지 않던 버그 + Slack None 필드로 알림 유실

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -150,34 +150,45 @@ def is_target_asset(cve_data: Dict) -> Tuple[bool, Optional[str], Optional[str]]
             has_wildcard = True
             continue
 
-        # 1차: affected 필드의 구조화된 vendor/product 매칭
-        for affected in cve_data.get('affected', []):
-            a_vendor = _norm(affected.get('vendor', ''))
-            a_product = _norm(affected.get('product', ''))
+        # 벤더 무관 룰(*/product)은 벤더가 비어 있어도 제품만으로 판정해야 한다 —
+        # 애초에 '벤더를 모를 때' 쓰라고 있는 표기이므로, 벤더 불명을 이유로 건너뛰면
+        # 그 기능이 가장 필요한 케이스에서만 매칭이 실패한다.
+        vendor_agnostic = (t_vendor == "*")
 
-            # vendor가 N/A, Unknown이면 건너뛰기 (2·3차에서 확인)
-            if a_vendor in ('', 'unknown', 'n/a'):
+        # 1차: affected 필드의 구조화된 vendor/product 매칭
+        for affected in cve_data.get('affected') or []:
+            a_vendor = _norm(affected.get('vendor'))
+            a_product = _norm(affected.get('product'))
+
+            unknown_vendor = a_vendor in ('', 'unknown', 'n/a')
+            # 벤더가 필요한 룰인데 벤더가 불명 → 이 항목으로는 판정 불가 (2·3차에서 확인)
+            if unknown_vendor and not vendor_agnostic:
+                continue
+            # 벤더 무관 룰인데 제품마저 불명 → 판정 근거 없음
+            if vendor_agnostic and a_product in ('', 'unknown', 'n/a'):
                 continue
 
-            # 벤더 와일드카드(*/product): 벤더 무관, 제품만으로 매칭
-            vendor_match = (t_vendor == "*") or (t_vendor in a_vendor) or (a_vendor in t_vendor)
+            vendor_match = vendor_agnostic or (t_vendor in a_vendor) or (a_vendor in t_vendor)
             product_match = (t_product == "*") or (t_product in a_product) or (a_product in t_product)
 
             if vendor_match and product_match:
-                return True, f"Matched (affected): {a_vendor}/{a_product}", "asset"
+                return True, f"Matched (affected): {a_vendor or '*'}/{a_product}", "asset"
 
         # 2차: NVD CPE의 vendor/product 매칭 (affected가 비거나 불명일 때 보완)
-        for cpe in cve_data.get('nvd_cpe', []):
-            parts = cpe.split(':')
+        for cpe in cve_data.get('nvd_cpe') or []:
+            parts = str(cpe).split(':')
             if len(parts) < 5:
                 continue
             c_vendor, c_product = _norm(parts[3]), _norm(parts[4])
-            if c_vendor in ('', '*', '-'):
+            unknown_vendor = c_vendor in ('', '*', '-')
+            if unknown_vendor and not vendor_agnostic:
                 continue
-            vendor_match = (t_vendor == "*") or (t_vendor in c_vendor) or (c_vendor in t_vendor)
+            if vendor_agnostic and c_product in ('', '*', '-'):
+                continue
+            vendor_match = vendor_agnostic or (t_vendor in c_vendor) or (c_vendor in t_vendor)
             product_match = (t_product == "*") or (t_product in c_product) or (c_product in t_product)
             if vendor_match and product_match:
-                return True, f"Matched (NVD CPE): {c_vendor}/{c_product}", "asset"
+                return True, f"Matched (NVD CPE): {c_vendor or '*'}/{c_product}", "asset"
 
         # 3차(보조): description 텍스트 매칭
         desc_lower = str(cve_data.get('description') or '').lower()

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -46,12 +46,14 @@ class SlackNotifier:
 
     def collect_alert(self, cve_data: Dict, reason: str, report_url: Optional[str] = None) -> None:
         """개별 CVE 알림을 배치 결과에 수집 (thread-safe)"""
+        # 여기서 스칼라를 정규화해 두면 요약 집계(비교·정렬·슬라이싱)가 None에 걸려
+        # 통째로 실패하는 일이 없다 — 수집 시점 한 곳에서만 방어하면 충분하다.
         with self._lock:
             self._batch_results.append({
                 "id": cve_data['id'],
-                "title_ko": cve_data.get('title_ko', cve_data.get('title', 'N/A')),
-                "cvss": cve_data.get('cvss', 0),
-                "epss": cve_data.get('epss', 0),
+                "title_ko": cve_data.get('title_ko') or cve_data.get('title') or 'N/A',
+                "cvss": cve_data.get('cvss') or 0,
+                "epss": cve_data.get('epss') or 0,
                 "is_kev": cve_data.get('is_kev', False),
                 "has_poc": cve_data.get('has_poc', False),
                 # 요약의 '즉시 알림 N건' 집계(is_urgent)에 필요한 신호 — 빠지면 과소 집계된다
@@ -98,9 +100,12 @@ class SlackNotifier:
     def _send_urgent_alert(self, cve_data: Dict, report_url: Optional[str] = None) -> bool:
         """긴급 CVE 즉시 알림 (실제 악용·무기화 신호 또는 CVSS 9+)"""
         try:
-            display_title = cve_data.get('title_ko', cve_data.get('title', 'N/A'))
-            cvss = cve_data.get('cvss', 0)
-            epss = cve_data.get('epss', 0)
+            # None 안전 추출 — 값이 명시적 null이면 .get의 기본값이 발동하지 않아
+            # 비교 연산에서 TypeError가 나고, 예외를 삼키는 구조 탓에 긴급 알림이 통째로 유실된다.
+            # (판정부 is_urgent는 이미 같은 방식으로 방어하고 있어 기준을 맞춘다)
+            display_title = cve_data.get('title_ko') or cve_data.get('title') or 'N/A'
+            cvss = cve_data.get('cvss') or 0
+            epss = cve_data.get('epss') or 0
 
             # 긴급 배지 — '왜 긴급인지'를 배지로 그대로 보여준다
             badges = []


### PR DESCRIPTION
시나리오 기반 검증(자산 등록 방식 27케이스 · Slack 전송 19케이스)에서 발견.

[버그 1] '벤더 모를 때 쓰라'고 만든 표기가 정작 벤더 불명일 때만 실패
is_target_asset의 1·2차 매칭이 'a_vendor가 unknown/n-a면 continue'로 항목을 통째로 건너뛰었다. 벤더 무관 룰(*/product)은 제품만으로 판정하면 되는데도
벤더 결손을 이유로 스킵되어, 이 표기가 가장 필요한 케이스(벤더 미상 레코드)에서
매칭이 실패했다. NVD CPE 경로도 동일(CPE 벤더가 '*'인 경우).
→ 룰이 벤더를 요구할 때만 스킵하고, 벤더 무관 룰은 제품 유효성만 확인하도록 분리.

[버그 2] cvss/epss가 null이면 긴급 Slack 알림이 통째로 유실
_send_urgent_alert가 .get('cvss', 0)을 쓰는데 값이 명시적 null이면 기본값이 발동하지 않아 '>= 9.0' 비교에서 TypeError. 예외를 삼키는 구조라 로그만 남고 긴급 알림이 사라졌다. 판정부 is_urgent는 이미 방어하고 있어 기준도 어긋나 있었음. → 전송부를 동일하게 None 안전 처리 + collect_alert에서 스칼라를 정규화해
  배치 요약 집계(비교·정렬)까지 한 번에 보호(요약 전체 유실 방지).

검증(시나리오 전수):
  자산 — 벤더+제품 / 벤더만(vendor/*) / 제품만(*/product) / 전체감시(*/*) /
        혼합 / 다중 등록 × (정확일치·대소문자·언더스코어·CPE·설명·벤더null) 27케이스
  Slack — 긴급 5신호 · 배치 수집/요약 · 5xx 재시도 · 최종실패 무중단 ·
        전송 후 배치 초기화 · 결손/None 필드 · 운영 경고 19케이스
  + 기존 스텁 9종, 브라우저 E2E 2종 전부 통과


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd