### PR TITLE
fix: 번역 429/503 — 일일 한도 추적을 실행 간에 유지하고 오류별 대응 분리

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -8,7 +8,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from typing import Dict, Optional
 from logger import logger
 from config import config
-from rate_limiter import rate_limit_manager
+from rate_limiter import rate_limit_manager, gemini_error_kind
 
 class AnalyzerError(Exception):
     """분석 관련 에러"""
@@ -128,7 +128,8 @@ class Analyzer:
             logger.warning(f"{cve_data['id']}: Gemini 비상 티어도 RPD 소진 → fallback")
             return None
         try:
-            rate_limit_manager.check_and_wait("gemini_analysis")
+            if not rate_limit_manager.check_and_wait("gemini_analysis"):
+                return None   # 위 is_rpd_exhausted와 별개로, 동시 실행 중 소진된 경우
             response = self.gemini_client.models.generate_content(
                 model=model,
                 contents=prompt,
@@ -153,9 +154,10 @@ class Analyzer:
             logger.info(f"{cve_data['id']}: Analysis complete (model={model}, 비상 티어)")
             return result
         except Exception as e:
-            msg = str(e).lower()
-            # 일간 quota 429 → 대기 무의미, 즉시 소진 마킹 (이후 CVE는 바로 fallback)
-            if "429" in msg or "resource_exhausted" in msg or "quota" in msg:
+            # 일간 quota 429 → 대기 무의미, 즉시 소진 마킹 (이후 CVE는 바로 fallback).
+            # 분당 한도 429는 마킹하지 않는다 — 소진 상태는 상태 파일로 실행 간에 유지되므로
+            # 오판하면 비상 분석 티어가 최대 24시간 잠긴다.
+            if gemini_error_kind(str(e)) == "rpd":
                 rate_limit_manager.mark_rpd_exhausted("gemini_analysis")
             logger.warning(f"{cve_data['id']}: Gemini 비상 분석 실패: {e}")
             return None

--- a/src/collector.py
+++ b/src/collector.py
@@ -60,6 +60,15 @@ def read_failure_state() -> Tuple[Dict[str, int], Dict[str, str]]:
         {k: str(v) for k, v in quarantined.items()},
     )
 
+def read_rpd_state() -> Dict[str, Dict[str, int]]:
+    """이전 실행이 남긴 일일 요청 수(RPD) 버킷. 없으면 빈 dict.
+
+    프로세스는 매 실행 새로 뜨므로 메모리 카운터만으로는 항상 0에서 시작한다 —
+    시간당 실행되는 파이프라인에서는 무료 티어 일일 한도(Gemma 1,500)를 스스로
+    지킬 수 없어 공급자가 429로 끊어버린다. 워터마크와 같은 파일에 이어붙인다."""
+    rpd = _read_state().get("rpd")
+    return rpd if isinstance(rpd, dict) else {}
+
 def active_quarantine(quarantined: Dict[str, str], retry_after_hours: int) -> Set[str]:
     """아직 격리 유효기간이 지나지 않은 CVE 집합. 기간이 지나면 자동 해제되어 재시도된다
     (일시 장애가 연속으로 겹쳐 격리된 경우 스스로 회복하게 하는 안전장치)."""
@@ -76,11 +85,15 @@ def active_quarantine(quarantined: Dict[str, str], retry_after_hours: int) -> Se
 
 def write_watermark(dt_utc: datetime.datetime,
                     failures: Optional[Dict[str, int]] = None,
-                    quarantined: Optional[Dict[str, str]] = None) -> None:
-    """처리 완료 지점(UTC) + 실패 추적 상태를 기록.
+                    quarantined: Optional[Dict[str, str]] = None,
+                    rpd: Optional[Dict[str, Dict[str, int]]] = None) -> None:
+    """처리 완료 지점(UTC) + 실패 추적 상태 + 일일 요청 수(RPD)를 기록.
 
     실패 추적은 '독약 레코드'가 워터마크를 영구 고정하는 것을 막기 위한 것이다 —
-    상세는 main._main의 워터마크 계산 주석 참조."""
+    상세는 main._main의 워터마크 계산 주석 참조.
+
+    rpd=None이면 파일에 있던 값을 그대로 남긴다 — 번역을 한 건도 하지 않고 끝나는
+    실행(신규 CVE 없음)이 이전 실행의 사용량 기록을 지워버리면 안 되기 때문이다."""
     try:
         os.makedirs(os.path.dirname(_STATE_PATH), exist_ok=True)
         payload = {"last_processed_until": dt_utc.astimezone(pytz.UTC).isoformat()}
@@ -88,11 +101,30 @@ def write_watermark(dt_utc: datetime.datetime,
             payload["failures"] = failures
         if quarantined:
             payload["quarantined"] = quarantined
+        carried = rpd if rpd is not None else _read_state().get("rpd")
+        if carried:
+            payload["rpd"] = carried
         with open(_STATE_PATH, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=1, sort_keys=True)
         logger.info(f"워터마크 저장: {payload['last_processed_until']}")
     except OSError as e:
         logger.warning(f"워터마크 저장 실패: {e}")
+
+def write_rpd_state(rpd: Dict[str, Dict[str, int]]) -> None:
+    """RPD 버킷만 갱신한다 (워터마크·격리 상태는 건드리지 않음).
+
+    번역 백필처럼 워터마크 저장 이후에 소비되는 호출까지 사용량에 반영하기 위한 것."""
+    try:
+        data = _read_state()
+        if rpd:
+            data["rpd"] = rpd
+        else:
+            data.pop("rpd", None)
+        os.makedirs(os.path.dirname(_STATE_PATH), exist_ok=True)
+        with open(_STATE_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=1, sort_keys=True)
+    except OSError as e:
+        logger.warning(f"RPD 상태 저장 실패: {e}")
 
 class Collector:
     def __init__(self):

--- a/src/main.py
+++ b/src/main.py
@@ -13,12 +13,13 @@ from google.genai import types
 from logger import logger
 from config import config
 from collector import (Collector, read_watermark, write_watermark,
-                       read_failure_state, active_quarantine)
+                       read_failure_state, active_quarantine,
+                       read_rpd_state, write_rpd_state)
 from database import ArgusDB
 from notifier import SlackNotifier
 from analyzer import Analyzer
 from rule_manager import RuleManager
-from rate_limiter import rate_limit_manager
+from rate_limiter import rate_limit_manager, gemini_error_kind
 
 # KST 타임존 (한국 표준시)
 KST = pytz.timezone('Asia/Seoul')
@@ -418,7 +419,10 @@ Do NOT add intro/outro.
     max_attempts = 3 if retry_on_transient else 1
     for attempt in range(1, max_attempts + 1):
         try:
-            rate_limit_manager.check_and_wait("gemini")
+            if not rate_limit_manager.check_and_wait("gemini"):
+                # 일일 한도 소진 — 호출해봐야 429만 받는다
+                _tr_bump("en_rpd")
+                return fallback
             response = gemini_client.models.generate_content(
                 model=config.MODEL_PHASE_0,
                 contents=prompt,
@@ -449,27 +453,75 @@ Do NOT add intro/outro.
                 if line.startswith("내용:"):
                     desc_ko = line.replace("내용:", "").strip()
 
+            _tr_bump("ok")
             return title_ko, desc_ko
 
         except Exception as e:
             msg = str(e)
-            if retry_on_transient and _is_transient_gemini_error(msg) and attempt < max_attempts:
-                wait = 2 * attempt  # 2s, 4s
-                logger.warning(f"번역 일시오류({attempt}/{max_attempts}): {e} → {wait}s 후 재시도")
+            kind = _gemini_error_kind(msg)
+            if kind == "rpd":
+                # 공급자가 먼저 일일 소진을 알려줬다 = 우리 카운터가 실제보다 적게 셌다는 뜻.
+                # 소진으로 마킹해 이번 실행의 남은 번역이 429를 반복하지 않게 한다.
+                rate_limit_manager.mark_rpd_exhausted("gemini")
+                logger.warning("번역 일일 한도(RPD) 소진 — 이후 번역은 영문 폴백")
+                _tr_bump("en_rpd")
+                return fallback
+            if kind in ("rate", "transient") and attempt < max_attempts:
+                wait = _gemini_backoff(kind, attempt, msg)
+                logger.warning(f"번역 {kind} 오류({attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
                 time.sleep(wait)
                 continue
-            logger.warning(f"번역 실패: {e}, 원본 사용")
+            logger.warning(f"번역 실패({kind}): {e}, 원본 사용")
+            _tr_bump(f"en_{kind}")
             return fallback
 
     return fallback
 
 
-def _is_transient_gemini_error(msg: str) -> bool:
-    """Gemma 일시 서버 오류(재시도 가치 있음) 판별.
-    상태 코드는 단어 경계로 매칭 — "limit: 1500" 같은 숫자에 "500"이 오탐되지 않게."""
-    return bool(re.search(r'\b(500|503)\b', msg)) or any(t in msg for t in (
-        "INTERNAL", "UNAVAILABLE", "high demand", "overloaded", "try again"
-    ))
+def _gemini_backoff(kind: str, attempt: int, msg: str) -> float:
+    """재시도 전 대기 시간. 분당 한도(429)는 서버가 알려준 재개 시각을 우선 따르되,
+    파이프라인이 통째로 잠들지 않도록 상한(30초)을 둔다."""
+    if kind == "rate":
+        hinted = rate_limit_manager.parse_retry_after(msg)
+        return min(hinted if hinted else 8.0 * attempt, 30.0)
+    return 2.0 * attempt  # 503/500: 2s, 4s
+
+
+# 오류 분류는 rate_limiter가 소유한다 — 분석 경로(analyzer)와 같은 기준을 써야
+# 분당 한도를 일일 소진으로 오판해 하루치를 버리는 일이 한쪽에서만 생기지 않는다.
+_gemini_error_kind = gemini_error_kind
+
+
+# 번역 결과 집계 — 왜 영문이 남았는지(일일한도/분당한도/서버오류/형식오류)를 실행 로그
+# 한 줄로 남긴다. 원인별 건수가 없으면 "가끔 503이 난다" 이상으로 진단할 수 없다.
+_TR_LOCK = threading.Lock()
+_TR_STATS: Dict[str, int] = {}
+_TR_LABELS = [("en_rpd", "일일한도"), ("en_rate", "분당한도"), ("en_transient", "서버오류"),
+              ("en_parse", "형식오류"), ("en_deadline", "시간초과"), ("en_other", "기타")]
+# _translate_chunk가 돌려준 사유 → 집계 키
+_TR_REASON_KEY = {"skip": "en_rpd", "rate": "en_rate", "transient": "en_transient",
+                  "parse": "en_parse", "other": "en_other", "api": "en_other"}
+
+
+def _tr_bump(key: str, n: int = 1) -> None:
+    if n <= 0:
+        return
+    with _TR_LOCK:
+        _TR_STATS[key] = _TR_STATS.get(key, 0) + n
+
+
+def _log_translation_summary() -> None:
+    """실행 누적 번역 결과 한 줄 요약 (배치 호출 종료 시점마다 갱신 출력)."""
+    with _TR_LOCK:
+        snap = dict(_TR_STATS)
+    ok = snap.get("ok", 0)
+    fallback = sum(snap.get(k, 0) for k, _ in _TR_LABELS)
+    if not (ok or fallback):
+        return
+    breakdown = " · ".join(f"{label} {snap.get(key, 0)}" for key, label in _TR_LABELS)
+    used, limit = rate_limit_manager.rpd_status("gemini")
+    logger.info(f"🈯 번역 요약(누적): 한글 {ok}건 · 영문폴백 {fallback}건 "
+                f"({breakdown}) · Gemma RPD {used:,}/{limit:,}")
 
 
 def generate_korean_summaries_batch(items: List[Dict], high_risk_ids: set,
@@ -520,23 +572,33 @@ def generate_korean_summaries_batch(items: List[Dict], high_risk_ids: set,
                     state["deadline_warned"] = True
             for it in chunk:
                 out[it['id']] = (it['title'], (it['description'] or '')[:200])
+            _tr_bump("en_deadline", len(chunk))
             return out
         try:
             # 배치 시도 — 호출 수가 적으므로 항상 일시오류 재시도 허용
-            parsed = _translate_chunk(chunk, retry_on_transient=True)
+            parsed, reason = _translate_chunk(chunk, retry_on_transient=True)
             if parsed is not None:
                 out.update(parsed)
-            else:
-                # 배치 파싱 실패 → 개별 텍스트 번역으로 폴백(한글 보장). 이 CVE들은 대시보드에
-                # 노출되므로 영문 방치보다 개별 번역 비용이 낫다.
+                _tr_bump("ok", len(chunk))
+            elif reason == "parse":
+                # 응답 형식만 깨진 경우 → 개별 텍스트 번역으로 폴백(한글 보장). 이 CVE들은
+                # 대시보드에 노출되므로 영문 방치보다 개별 번역 비용이 낫다.
+                # (개별 호출의 성공/실패 집계는 generate_korean_summary가 직접 기록한다.)
                 with lock:
                     state["fell_back"] += len(chunk)
                 for it in chunk:
                     out[it['id']] = _individual(it, allow_retry=True)
+            else:
+                # API 자체가 실패(429/503/한도 소진) → 개별 재시도는 같은 오류를 6배로
+                # 늘릴 뿐이다. 영문으로 두고 다음 실행의 번역 백필이 회수한다.
+                for it in chunk:
+                    out[it['id']] = (it['title'], (it['description'] or '')[:200])
+                _tr_bump(_TR_REASON_KEY.get(reason, "en_other"), len(chunk))
         except Exception as e:
             logger.warning(f"번역 청크 실패 → 영문 폴백: {e}")
             for it in chunk:
                 out.setdefault(it['id'], (it['title'], (it['description'] or '')[:200]))
+            _tr_bump("en_other", len(chunk))
         with lock:
             state["done"] += 1
             done = state["done"]
@@ -550,13 +612,22 @@ def generate_korean_summaries_batch(items: List[Dict], high_risk_ids: set,
             results.update(out)
 
     if state["fell_back"]:
-        logger.info(f"번역: 배치 실패 {state['fell_back']}건 → 개별 번역으로 한글화 완료")
+        logger.info(f"번역: 배치 응답 형식 파손 {state['fell_back']}건 → 개별 번역으로 재시도")
+    _log_translation_summary()
     return results
 
 
-def _translate_chunk(chunk: List[Dict], retry_on_transient: bool) -> Optional[Dict[str, Tuple[str, str]]]:
-    """청크(≤batch_size건) 1회 Gemma 호출 번역. 성공 시 id→(제목,요약) dict, 실패 시 None.
-    응답 JSON에서 누락된 항목은 영문 폴백으로 채워 반환값은 항상 청크 전체를 커버한다."""
+def _translate_chunk(chunk: List[Dict],
+                     retry_on_transient: bool) -> Tuple[Optional[Dict[str, Tuple[str, str]]], str]:
+    """청크(≤batch_size건) 1회 Gemma 호출 번역. (결과, 사유)를 반환한다.
+
+    사유를 함께 돌려주는 이유: 호출부의 '개별 번역 폴백'은 배치 JSON이 깨졌을 때만
+    의미가 있다. 429/503처럼 API 자체가 실패한 청크를 개별로 재시도하면 같은 오류를
+    6배로 늘려 한도만 더 태운다(429가 429를 부르는 증폭). 사유가 있어야 구분된다.
+
+    사유: "ok"(성공) · "parse"(응답 형식 파손 → 개별 폴백 가치 있음) ·
+          "api"(호출 실패 → 개별 폴백 무의미) · "skip"(일일 한도 소진)
+    응답 JSON에서 누락된 항목은 영문 폴백으로 채워 성공 시 반환값은 청크 전체를 커버한다."""
     # 입력 500자·출력 2줄 요약으로 제한 — 배치당 생성 토큰을 줄여 호출당 소요를 절반 이하로
     # (관측: 출력이 크면 배치당 ~60초 → 40청크에 40분, 실행 타임아웃의 주범이었음)
     numbered = "\n".join(
@@ -574,7 +645,8 @@ CVEs:
     max_attempts = 3 if retry_on_transient else 1
     for attempt in range(1, max_attempts + 1):
         try:
-            rate_limit_manager.check_and_wait("gemini")
+            if not rate_limit_manager.check_and_wait("gemini"):
+                return None, "skip"
             response = gemini_client.models.generate_content(
                 model=config.MODEL_PHASE_0,
                 contents=prompt,
@@ -601,11 +673,11 @@ CVEs:
                 m = re.search(r'\[[\s\S]*\]', text)
                 if not m:
                     logger.warning(f"일괄 번역 파싱 실패 (JSON 배열 없음, 시도 {attempt})")
-                    return None
+                    return None, "parse"
                 arr = json.loads(m.group())
 
             if not isinstance(arr, list):
-                return None
+                return None, "parse"
             by_n = {int(o.get('n', 0)): o for o in arr if isinstance(o, dict)}
             out: Dict[str, Tuple[str, str]] = {}
             for n, it in enumerate(chunk, 1):
@@ -613,18 +685,27 @@ CVEs:
                 title_ko = (o.get('title_ko') or '').strip() or it['title']
                 desc_ko = (o.get('desc_ko') or '').strip() or (it['description'] or '')[:200]
                 out[it['id']] = (title_ko, desc_ko)
-            return out
+            return out, "ok"
 
+        except json.JSONDecodeError as e:
+            # 폴백 정규식으로 뽑은 조각도 JSON이 아니었다 = 응답 형식 문제
+            logger.warning(f"일괄 번역 파싱 실패: {e}")
+            return None, "parse"
         except Exception as e:
             msg = str(e)
-            if retry_on_transient and _is_transient_gemini_error(msg) and attempt < max_attempts:
-                wait = 2 * attempt
-                logger.warning(f"일괄 번역 일시오류({attempt}/{max_attempts}): {e} → {wait}s 후 재시도")
+            kind = _gemini_error_kind(msg)
+            if kind == "rpd":
+                rate_limit_manager.mark_rpd_exhausted("gemini")
+                logger.warning("일괄 번역 일일 한도(RPD) 소진 — 이후 번역은 영문 폴백")
+                return None, "skip"
+            if kind in ("rate", "transient") and attempt < max_attempts:
+                wait = _gemini_backoff(kind, attempt, msg)
+                logger.warning(f"일괄 번역 {kind} 오류({attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
                 time.sleep(wait)
                 continue
-            logger.warning(f"일괄 번역 청크 실패: {e}")
-            return None
-    return None
+            logger.warning(f"일괄 번역 청크 실패({kind}): {e}")
+            return None, kind
+    return None, "api"
 
 # ==============================================================================
 # [3] GitHub Issue 생성/업데이트
@@ -1472,7 +1553,12 @@ def _main():
     collector = Collector()
     db = ArgusDB()
     notifier = SlackNotifier()
-    
+
+    # 이전 실행들의 일일 요청 수(RPD)를 이어받는다 — 프로세스가 매 실행 새로 뜨는 탓에
+    # 카운터가 늘 0에서 시작해 무료 티어 일일 한도를 스스로 못 지키던 문제의 해소.
+    # 첫 Gemma 호출(에스컬레이션 스윕 단건 번역)보다 먼저 실행되어야 한다.
+    rate_limit_manager.import_rpd_state(read_rpd_state())
+
     # Step 3: 공식 룰 재발견
     check_for_official_rules()
     
@@ -1508,7 +1594,8 @@ def _main():
 
     if not fetched:
         # 창 내 신규 커밋 없음 → 창 끝까지만 전진 (창 이후 커밋은 다음 실행이 수집)
-        write_watermark(min(catchup_horizon, run_start_utc))
+        write_watermark(min(catchup_horizon, run_start_utc),
+                        rpd=rate_limit_manager.export_rpd_state())
         logger.info("처리할 CVE 없음 (워터마크 전진)")
         return
 
@@ -1717,10 +1804,13 @@ def _main():
     quarantined = {k: v for k, v in quarantined.items()
                    if _iso_after(v, stale_cut)}
     fail_counts = {k: v for k, v in fail_counts.items() if k in held_now or v > 0}
-    write_watermark(new_watermark, failures=fail_counts, quarantined=quarantined)
+    write_watermark(new_watermark, failures=fail_counts, quarantined=quarantined,
+                    rpd=rate_limit_manager.export_rpd_state())
 
     # 워터마크 저장 이후에 백필 — 여기서 무슨 일이 나도 이번 회차의 전진은 이미 확정이다
     backfill_translations(db, soft_deadline_ts)
+    # 백필이 소비한 호출까지 반영 (워터마크는 그대로 두고 사용량만 갱신)
+    write_rpd_state(rate_limit_manager.export_rpd_state())
 
     success_count = sum(1 for s in status_by_id.values() if s == 'success')
 

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -3,8 +3,39 @@ import threading
 import re
 from typing import Dict, Optional
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logger import logger
+
+def is_transient_gemini_error(msg: str) -> bool:
+    """Gemini/Gemma 일시 서버 오류(재시도 가치 있음) 판별.
+    상태 코드는 단어 경계로 매칭 — "limit: 1500" 같은 숫자에 "500"이 오탐되지 않게."""
+    return bool(re.search(r'\b(500|503)\b', msg)) or any(t in msg for t in (
+        "INTERNAL", "UNAVAILABLE", "high demand", "overloaded", "try again"
+    ))
+
+
+def gemini_error_kind(msg: str) -> str:
+    """Google AI Studio 호출 예외를 '어떻게 대응해야 하는가'로 분류한다.
+
+    rpd       — 일일 요청 한도 소진(429). 기다려도 오늘 안에는 풀리지 않는다 →
+                즉시 소진 마킹하고 남은 호출은 폴백.
+    rate      — 분당 요청 한도(429). 짧게 기다리면 풀린다 → 백오프 후 재시도.
+    transient — 구글 서버측 일시 오류(500/503). 백오프 후 재시도.
+    other     — 안전 차단·잘못된 요청 등. 재시도해도 결과가 같다.
+
+    분당/일일 모두 429로 오기 때문에 메시지의 per-day 표기가 있을 때만 rpd로 본다.
+    분당 한도를 일일 소진으로 오판하면 — 소진 상태가 상태 파일로 실행 간에 유지되므로 —
+    아직 남은 하루치 한도를 통째로 버리게 된다.
+    """
+    low = msg.lower()
+    if "429" in msg or "resource_exhausted" in low or "resource exhausted" in low:
+        if any(t in low for t in ("perday", "per day", "per-day", "daily")):
+            return "rpd"
+        return "rate"
+    if is_transient_gemini_error(msg):
+        return "transient"
+    return "other"
+
 
 @dataclass
 class RateLimitInfo:
@@ -142,9 +173,15 @@ class RateLimitManager:
             "gemini_analysis": 1_000,  # flash-lite (분석 비상): 보수적 기본값 — 콘솔 확인 후 조정
         }
         self._rpd_used: Dict[str, int] = {api: 0 for api in self._rpd_limits}
-        self._rpd_reset_at: Dict[str, datetime] = {
-            api: datetime.now() + timedelta(hours=24) for api in self._rpd_limits
-        }
+        # RPD는 시간 단위 버킷의 롤링 24시간 합으로 센다. 이유는 두 가지다.
+        #  ① 프로세스는 매 실행 새로 뜨므로 메모리 카운터만으로는 항상 0에서 시작한다
+        #     → 한도를 모른 채 계속 호출해 결국 공급자가 429로 끊는다. 버킷을 상태 파일에
+        #     저장해 실행 간에 이어붙인다(import_rpd_state / export_rpd_state).
+        #  ② 공급자의 일간 리셋 시각(태평양 자정 등)을 우리가 정확히 알 수 없다. 롤링
+        #     24시간 합은 '마지막 리셋 이후 사용량'보다 항상 크거나 같아서 안전한 쪽으로
+        #     틀린다 — 달력일 기준으로 세면 UTC 새벽 구간에서 과소 집계돼 초과할 수 있다.
+        self._rpd_buckets: Dict[str, Dict[str, int]] = {api: {} for api in self._rpd_limits}
+        self._rpd_skip_warned: Dict[str, bool] = {}   # SKIP 경고 1회만 (로그 스팸 방지)
 
         logger.info("Rate Limit Manager v3.5 초기화 완료 (Thread-Safe + 모델별 RPD/TPD 캐스케이드)")
 
@@ -204,6 +241,16 @@ class RateLimitManager:
 
         exhausted_wait = 0.0
         with self._lock:
+            # 일간 한도(RPD) 소진은 분 단위 대기로 풀리지 않는다 → 즉시 False로 알려
+            # 호출부가 폴백하게 한다. 이 검사가 없으면 소진 마킹을 해도 계속 호출한다.
+            rpd_limit = self._rpd_limits.get(api_name)
+            if rpd_limit is not None and self._rpd_rolling_sum(api_name) >= rpd_limit:
+                if not self._rpd_skip_warned.get(api_name):
+                    logger.warning(f"⏭️ {api_name} 일일 한도(RPD {rpd_limit:,}) 소진 — "
+                                   f"이번 실행의 후속 호출은 SKIP")
+                    self._rpd_skip_warned[api_name] = True
+                return False
+
             info = self.limits[api_name]
             now = datetime.now()
 
@@ -308,14 +355,12 @@ class RateLimitManager:
             self.stats["total_calls"] += 1
             logger.debug(f"{api_name} 호출 기록: {info.used}/{info.limit} ({info.usage_percent:.1f}%)")
 
-            # RPD 트래킹 (일 윈도우) — 토큰과 무관하게 호출 1건마다 누적 (Gemma는 TPM 무제한)
+            # RPD 트래킹 (롤링 24h) — 토큰과 무관하게 호출 1건마다 누적 (Gemma는 TPM 무제한)
             if api_name in self._rpd_limits:
-                now = datetime.now()
-                if now >= self._rpd_reset_at[api_name]:
-                    self._rpd_used[api_name] = 0
-                    self._rpd_reset_at[api_name] = now + timedelta(hours=24)
-                    logger.info(f"🔄 {api_name} RPD 리셋")
-                self._rpd_used[api_name] += 1
+                buckets = self._rpd_buckets[api_name]
+                key = self._rpd_bucket_key()
+                buckets[key] = buckets.get(key, 0) + 1
+                self._rpd_used[api_name] = self._rpd_rolling_sum(api_name)
                 rpd_limit = self._rpd_limits[api_name]
                 rpd_pct = (self._rpd_used[api_name] / rpd_limit) * 100
                 logger.debug(f"{api_name} RPD: {self._rpd_used[api_name]:,}/{rpd_limit:,} ({rpd_pct:.1f}%)")
@@ -361,21 +406,79 @@ class RateLimitManager:
         with self._lock:
             return self._groq_model_exhausted(model, required_tokens)
 
+    @staticmethod
+    def _rpd_bucket_key(when: Optional[datetime] = None) -> str:
+        """RPD 버킷 키 = UTC 시간 단위. 로컬 시간대에 무관하게 재현되도록 UTC로 고정."""
+        return (when or datetime.now(timezone.utc)).astimezone(
+            timezone.utc).strftime("%Y-%m-%dT%H")
+
+    def _rpd_rolling_sum(self, api_name: str) -> int:
+        """최근 24시간 버킷 합. 오래된 버킷은 이 시점에 정리한다. (호출자가 락 보유)"""
+        buckets = self._rpd_buckets.get(api_name)
+        if not buckets:
+            return 0
+        cutoff = self._rpd_bucket_key(datetime.now(timezone.utc) - timedelta(hours=23))
+        for key in [k for k in buckets if k < cutoff]:
+            del buckets[key]
+        return sum(buckets.values())
+
+    def import_rpd_state(self, state: Dict[str, Dict[str, int]]) -> None:
+        """이전 실행의 RPD 버킷을 불러온다. 형식이 어긋난 값은 조용히 버린다
+        (상태 파일이 손상돼도 파이프라인이 멈추면 안 되므로)."""
+        if not isinstance(state, dict):
+            return
+        with self._lock:
+            for api, buckets in state.items():
+                if api not in self._rpd_limits or not isinstance(buckets, dict):
+                    continue
+                clean = {str(k): int(v) for k, v in buckets.items()
+                         if isinstance(v, (int, float)) and int(v) > 0}
+                self._rpd_buckets[api] = clean
+                self._rpd_used[api] = self._rpd_rolling_sum(api)
+                if self._rpd_used[api]:
+                    logger.info(f"🔁 {api} RPD 이월: 최근 24h {self._rpd_used[api]:,}"
+                                f"/{self._rpd_limits[api]:,}")
+
+    def export_rpd_state(self) -> Dict[str, Dict[str, int]]:
+        """상태 파일에 저장할 RPD 버킷. 최근 24시간만 남긴다."""
+        with self._lock:
+            out = {}
+            for api in self._rpd_limits:
+                self._rpd_rolling_sum(api)      # 오래된 버킷 정리
+                if self._rpd_buckets[api]:
+                    out[api] = dict(self._rpd_buckets[api])
+            return out
+
+    def rpd_status(self, api_name: str) -> tuple:
+        """(최근 24h 사용량, 한도). 추적 대상이 아니면 (0, 0) — 로그 표시용."""
+        with self._lock:
+            limit = self._rpd_limits.get(api_name)
+            if limit is None:
+                return (0, 0)
+            return (self._rpd_rolling_sum(api_name), limit)
+
     def is_rpd_exhausted(self, api_name: str) -> bool:
         """일간 요청 한도(RPD) 추적 대상 API의 소진 여부. 미추적 API는 False."""
         with self._lock:
             limit = self._rpd_limits.get(api_name)
             if limit is None:
                 return False
-            if datetime.now() >= self._rpd_reset_at.get(api_name, datetime.min):
-                return False  # 일간 윈도우 경과 → 다음 record_call에서 리셋됨
-            return self._rpd_used.get(api_name, 0) >= limit
+            return self._rpd_rolling_sum(api_name) >= limit
 
     def mark_rpd_exhausted(self, api_name: str) -> None:
-        """RPD 소진 마킹 (일간 quota 429 수신 시 — 대기 무의미, 즉시 스킵 전환)."""
+        """RPD 소진 마킹 (일간 quota 429 수신 시 — 대기 무의미, 즉시 스킵 전환).
+
+        공급자가 먼저 429를 냈다는 건 우리 카운터가 실제보다 적게 세고 있었다는 뜻이다.
+        남은 한도를 0으로 만들어 이번 실행에서 더 호출하지 않게 한다."""
         with self._lock:
             if api_name in self._rpd_limits:
-                self._rpd_used[api_name] = self._rpd_limits[api_name]
+                limit = self._rpd_limits[api_name]
+                shortfall = max(0, limit - self._rpd_rolling_sum(api_name))
+                if shortfall:
+                    key = self._rpd_bucket_key()
+                    self._rpd_buckets[api_name][key] = (
+                        self._rpd_buckets[api_name].get(key, 0) + shortfall)
+                self._rpd_used[api_name] = self._rpd_rolling_sum(api_name)
                 logger.warning(f"🚫 {api_name} 일일 한도(RPD) 소진 마킹 — SKIP 전환")
 
     def handle_429(self, api_name: str, retry_after: Optional[float] = None,


### PR DESCRIPTION
시간당 실행되는 파이프라인에서 번역(Gemma)이 429/503을 반복하던 원인 세 가지를 각각 해소한다.

1) 일일 요청 수(RPD)가 매 실행 0으로 초기화되던 문제
   카운터가 프로세스 메모리에만 있어 한도 1,500을 스스로 지킬 수 없었고, 결국
   공급자가 429로 끊었다. 시간 단위 버킷의 롤링 24시간 합으로 세고 워터마크와
   같은 상태 파일(pipeline_state.json)에 저장해 실행 간에 이어붙인다.
   롤링 합을 쓰는 이유: 공급자의 일간 리셋 시각을 알 수 없는데, 롤링 24시간은
   '마지막 리셋 이후 사용량'보다 항상 크거나 같아 안전한 쪽으로 틀린다.

2) 429를 받고도 계속 호출하던 문제
   check_and_wait가 RPD 소진 시 False를 반환하고, 호출부가 이를 실제로 확인한다.
   일일 한도 429를 받으면 즉시 소진 마킹해 남은 호출을 영문 폴백으로 돌린다.
   분당 한도 429는 마킹하지 않고 서버가 알려준 재개 시각(상한 30초)만큼만
   기다렸다가 재시도한다 — 소진 상태가 실행 간에 유지되므로 오판하면 남은
   하루치를 통째로 버리게 된다.

3) API 실패가 개별 폴백 6콜로 증폭되던 문제
   _translate_chunk가 (결과, 사유)를 반환한다. 개별 번역 폴백은 배치 JSON이
   깨졌을 때(parse)만 의미가 있다. 429/503으로 실패한 청크를 개별로 재시도하면
   같은 오류를 배치 크기만큼 늘려 한도만 더 태운다.

더불어 실행마다 번역 결과를 원인별로 집계해 한 줄로 남긴다
(한글 N건 · 영문폴백 M건 (일일한도/분당한도/서버오류/형식오류/시간초과/기타) · RPD). 원인별 건수가 없으면 503 빈도 변화를 관측할 수 없어 다음 조치를 정할 수 없다.

오류 분류(gemini_error_kind)는 rate_limiter가 소유해 번역과 분석 비상 티어가 같은 기준을 쓴다. 분석 경로는 그동안 모든 429·quota 문자열에 소진 마킹을 했는데, 소진 상태가 실행 간에 유지되면서 분당 한도 한 번에 비상 티어가 최대 24시간
잠기게 되므로 per-day 표기가 있을 때만 마킹하도록 좁혔다.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd