### PR TITLE
fix: 다중 브랜치 제품에서 '취약한데 수정판'으로 판정되던 오류 외 4건

### DIFF
--- a/src/backfill_vendors.py
+++ b/src/backfill_vendors.py
@@ -30,8 +30,10 @@ _NVD = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 _GAP_NO_KEY, _GAP_KEY = 8.0, 0.7
 
 
-def _fetch_cpe(cve_id: str, api_key: str) -> List[Dict]:
-    """NVD에서 CVE 하나의 CPE를 받아 affected 항목으로 변환. 실패하면 빈 리스트."""
+def _fetch_cpe(cve_id: str, api_key: str, existing: List[Dict] = None) -> List[Dict]:
+    """NVD에서 CVE 하나의 CPE를 받아 affected 항목으로 변환. 실패하면 빈 리스트.
+
+    existing을 넘기면 기존 제품명·버전 범위를 보존하고 벤더만 채운다."""
     headers = {"apiKey": api_key} if api_key else {}
     try:
         r = requests.get(_NVD, params={"cveId": cve_id}, headers=headers, timeout=60)
@@ -48,7 +50,7 @@ def _fetch_cpe(cve_id: str, api_key: str) -> List[Dict]:
             for node in conf.get("nodes") or []
             for m in node.get("cpeMatch") or []]
     # 변환 규칙은 수집 파이프라인과 공유한다 — 두 경로가 다른 벤더명을 만들면 안 된다
-    return affected_from_cpes(cpes)
+    return affected_from_cpes(cpes, existing)
 
 
 def main() -> int:
@@ -78,7 +80,7 @@ def main() -> int:
         state = row.get("last_alert_state")
         if not cve_id or not state:
             continue
-        affected = _fetch_cpe(cve_id, api_key)
+        affected = _fetch_cpe(cve_id, api_key, state.get("affected"))
         if affected:
             hit += 1
             new_state = dict(state)

--- a/src/collector.py
+++ b/src/collector.py
@@ -177,10 +177,30 @@ def parse_cpe(cpe: str) -> Optional[Tuple[str, str, str]]:
     return vendor, product, version
 
 
-def affected_from_cpes(cpes: List[str], limit: int = 5) -> List[Dict]:
-    """CPE 목록 → affected 항목. 같은 (벤더, 제품)은 한 번만 담는다.
-    표시용이라 limit을 넘길 이유가 없다(버전 범위가 많으면 CPE가 수십 개씩 나온다)."""
-    seen, out = set(), []
+def _meaningful(v) -> str:
+    """표시할 값이 있으면 그 값, 없으면 ''. CNA가 넣는 자리표시자를 걸러낸다."""
+    s = str(v or '').strip()
+    return '' if s.lower() in ('', 'unknown', 'n/a', '-', 'n/a (단일 버전)', '정보 없음') else s
+
+
+def _key(s: str) -> str:
+    """제품명 비교용 정규화 — CPE는 'postgresql', CNA는 'PostgreSQL'로 쓴다."""
+    return re.sub(r'[\s_-]+', '', str(s or '').lower())
+
+
+def affected_from_cpes(cpes: List[str], existing: List[Dict] = None,
+                       limit: int = 5) -> List[Dict]:
+    """CPE 목록 → affected 항목. 기존 항목이 있으면 덮어쓰지 않고 벤더만 채운다.
+
+    통째로 갈아끼우면 CNA가 준 정보를 잃는다. 실측으로 벤더 없는 198건 중 119건이
+    제품명과 상세 버전 범위를 갖고 있었다 — 예를 들어
+
+        product='PostgreSQL'  versions='18 부터 18.5 이전, 17 부터 17.11 이전, ...'
+
+    이걸 CPE 유래 항목(versions='정보 없음')으로 바꾸면 벤더 하나를 얻고 버전 범위를
+    통째로 버리는 셈이다. 그래서 제품명이 있는 항목은 그대로 두고 벤더만 채운다.
+    제품명조차 없는 항목(vendor/product 모두 n/a)만 CPE 유래 항목으로 대체한다."""
+    seen, derived = set(), []
     for cpe in cpes or []:
         parsed = parse_cpe(cpe)
         if not parsed:
@@ -190,15 +210,34 @@ def affected_from_cpes(cpes: List[str], limit: int = 5) -> List[Dict]:
         if key in seen:
             continue
         seen.add(key)
-        out.append({
+        derived.append({
             "vendor": vendor.replace('_', ' '),
             "product": product.replace('_', ' '),
             "versions": version if version not in ('*', '-', '') else "정보 없음",
             "patch_version": None,
         })
-        if len(out) >= limit:
+        if len(derived) >= limit:
             break
-    return out
+    if not derived:
+        return []
+
+    keepers = [a for a in (existing or []) if isinstance(a, dict) and _meaningful(a.get('product'))]
+    if not keepers:
+        return derived      # 살릴 게 없으면 CPE 유래로 채운다
+
+    # 제품명이 맞는 CPE에서 벤더를 가져온다. 못 찾으면 CPE 벤더가 하나뿐일 때만
+    # 그것을 쓴다 — 여러 벤더 중 아무거나 붙이면 틀린 벤더를 심는 셈이다.
+    by_product = {_key(d['product']): d['vendor'] for d in derived}
+    vendors = {d['vendor'] for d in derived}
+    sole = next(iter(vendors)) if len(vendors) == 1 else ''
+    out = []
+    for a in keepers:
+        vendor = by_product.get(_key(a.get('product'))) or sole
+        out.append({**a, "vendor": vendor} if vendor else dict(a))
+    # CNA가 언급하지 않은 제품이 CPE에 더 있으면 뒤에 덧붙인다 (버리지 않는다)
+    known = {_key(a.get('product')) for a in keepers}
+    out.extend(d for d in derived if _key(d['product']) not in known)
+    return out[:limit]
 
 
 class Collector:
@@ -1025,7 +1064,7 @@ class Collector:
         )
         if has_valid_vendor:
             return cve_data  # CVE 자체 데이터 우선
-        derived = affected_from_cpes(cpes)
+        derived = affected_from_cpes(cpes, existing)
         if derived:
             cve_data['affected'] = derived
             logger.info(f"  📦 NVD CPE로 영향자산 보강: {cve_data['id']} ({len(derived)}건)")

--- a/src/export_dashboard_data.py
+++ b/src/export_dashboard_data.py
@@ -45,6 +45,18 @@ def _l(state: dict, key: str) -> list:
     return v if isinstance(v, list) else []
 
 
+def _write_json(path: str, payload) -> None:
+    """임시 파일에 쓰고 원자적으로 바꿔치운다.
+
+    바로 덮어쓰면 도중에 죽었을 때 잘린 JSON이 남는다. 데이터 파일을 더는 커밋하지
+    않으므로 그 잘린 파일이 곧바로 배포돼 대시보드가 깨지고, 다음 실행이 그걸
+    출발점으로 읽는다. os.replace는 같은 파일시스템에서 원자적이다."""
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
 def export_cves(client, days: int = 90, since: str = None) -> list:
     """최근 N일 CVE 데이터 export (페이지네이션으로 전체 로드).
 
@@ -441,8 +453,11 @@ def apply_retention_policy(client, days: int = 120, marker_days: int = 30,
 
     tracked = _count(client, tracked=True)
     remaining = _count(client)
-    print(f"  현황: 전체 {remaining:,} · 추적 {tracked:,} · 마커 {remaining - tracked:,} "
-          f"· 이번 삭제 {deleted_count + purged_count + capped:,}", flush=True)
+    # '상태없음'은 마커(비자산 저위험 dedup용)와 보존정책이 JSONB를 비운 과거 행이
+    # 섞인 수다. 둘을 나누려면 조회가 한 번 더 필요한데 그 값으로 할 일이 없다.
+    print(f"  현황: 전체 {remaining:,} · 추적 {tracked:,} · 상태없음 {remaining - tracked:,} "
+          f"(마커 + 보존정책이 비운 과거 행) · 이번 삭제 "
+          f"{deleted_count + purged_count + capped:,}", flush=True)
 
     return cleaned
 
@@ -499,16 +514,14 @@ def main():
         print(f"  증분 export: 변경 {len(fresh)}건 → 병합 후 {len(cve_data)}건 "
               f"(직전 {len(previous)}건)", flush=True)
     cve_path = os.path.join(data_dir, "cves.json")
-    with open(cve_path, "w", encoding="utf-8") as f:
-        json.dump(cve_data, f, ensure_ascii=False, indent=2)
+    _write_json(cve_path, cve_data)
     print(f"  CVE: {len(cve_data)}건 → {cve_path}", flush=True)
 
     # 통계
     print("[2/4] 통계 집계...", flush=True)
     stats = export_stats(cve_data)
     stats_path = os.path.join(data_dir, "stats.json")
-    with open(stats_path, "w", encoding="utf-8") as f:
-        json.dump(stats, f, ensure_ascii=False, indent=2)
+    _write_json(stats_path, stats)
     print(f"  Stats → {stats_path}", flush=True)
 
     # 주간 리포트 (직전 ISO 주가 아직 발행되지 않았을 때만)

--- a/src/fetch_published.py
+++ b/src/fetch_published.py
@@ -12,6 +12,7 @@ GitHub Pages를 아티팩트로 배포하면 한 번의 배포가 사이트 전�
 
     python src/fetch_published.py cve-packages.json malicious-packages.json
 """
+import json
 import os
 import sys
 import urllib.request
@@ -47,10 +48,19 @@ def fetch(name: str, base: str) -> bool:
         return False
     if not data:
         return False
+    # 잘린 응답을 그대로 배포하면 대시보드가 깨진다 — 파싱되는지 먼저 본다.
+    if name.endswith(".json"):
+        try:
+            json.loads(data.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError) as e:
+            print(f"  {name}: 내려받은 내용이 온전치 않음({e}) — 무시", flush=True)
+            return False
     path = os.path.join(_DATA_DIR, name)
     os.makedirs(_DATA_DIR, exist_ok=True)
-    with open(path, "wb") as f:
+    tmp = f"{path}.tmp"
+    with open(tmp, "wb") as f:
         f.write(data)
+    os.replace(tmp, path)
     print(f"  {name}: 현재 사이트에서 이어받음 ({len(data) / 1e6:.1f} MB)", flush=True)
     return True
 

--- a/src/main.py
+++ b/src/main.py
@@ -380,21 +380,24 @@ def _epss_surge_candidates(collector: Collector, db: ArgusDB, exclude: set,
     return drifted
 
 
+def _wildcard_only() -> bool:
+    """감시 설정이 전체 감시(*/*)뿐인지. 그러면 매칭이 항상 참이라 매칭용 조회가 불필요."""
+    return any(t.get('vendor') == '*' and t.get('product') == '*'
+               for t in config.get_target_assets())
+
+
 def _needs_cpe_lookup(cve_data: Dict) -> bool:
-    """NVD CPE 선제 조회가 필요한지 — CVE에 유효한 벤더가 하나도 없으면 True.
+    """유효한 벤더가 하나도 없으면 True — NVD CPE로 채울 여지가 있다는 뜻.
 
-    조회 이유가 둘이다:
-      1) 자산 매칭 — 특정 자산 감시(*/* 아님)면 벤더 없이는 매칭 자체가 불가능해
-         감시 대상 CVE를 놓친다.
-      2) 표시·필터 — 전체 감시(*/*)라도 벤더가 비면 대시보드 벤더 필터에서 통째로
-         빠지고 리포트의 '영향 받는 자산'이 n/a로 남는다.
-
-    예전에는 1)만 보고 전체 감시에서 건너뛰었다. 매칭 관점에선 맞지만 그 부작용으로
-    표시용 벤더까지 같이 잃어, 추적 CVE의 1.6%(실측 198건)가 벤더 없이 남았다.
     원본 CNA 레코드가 'n/a'여도 NVD CPE에는 있는 경우가 있다
     (예: CVE-2020-29574 → cpe:2.3:o:sophos:cyberoamos).
 
-    비용은 벤더 없는 CVE에 대해서만 NVD 1회다(실측 유입의 1.6%)."""
+    조회가 필요한 이유는 둘이고, 호출 시점이 다르다:
+      1) 자산 매칭 — 특정 자산 감시(*/* 아님)면 벤더 없이는 매칭이 불가능하므로
+         is_target_asset 앞에서 조회해야 한다.
+      2) 표시·필터 — 벤더가 비면 대시보드 벤더 필터에서 통째로 빠진다. 이건 추적이
+         확정된 뒤에 채우면 된다. 마커로 끝날 CVE(전체 감시 + 저위험)는 affected를
+         저장조차 하지 않으므로 그 전에 조회하면 순수 낭비다."""
     return not any(
         str(a.get('vendor') or '').lower() not in ('', 'unknown', 'n/a')
         for a in (cve_data.get('affected') or [])
@@ -1127,9 +1130,9 @@ def prepare_single_cve(cve_id: str, collector: Collector, db: ArgusDB) -> Dict:
             return {"cve_id": cve_id, "status": "handled", "stage": "done"}
 
         # Step 2: 자산 필터링 (affected vendor/product 우선, NVD CPE 보조, description 보조)
-        # 유효 벤더가 없으면 NVD CPE를 조회해 affected를 채운다 — 매칭 소스 확보이자
-        # 대시보드 벤더 필터·리포트 표시를 위한 것이다(_needs_cpe_lookup 주석 참조).
-        if _needs_cpe_lookup(raw_data):
+        # 매칭에 벤더가 필요할 때만 선제 조회한다. 전체 감시(*/*)면 매칭이 항상 참이라
+        # 여기서 조회할 이유가 없고, 표시용 벤더는 추적이 확정된 뒤에 채운다(아래).
+        if not _wildcard_only() and _needs_cpe_lookup(raw_data):
             collector.fill_affected_from_nvd(raw_data)
         is_target, match_info, match_type = is_target_asset(raw_data)
         if not is_target:
@@ -1224,6 +1227,13 @@ def prepare_single_cve(cve_id: str, collector: Collector, db: ArgusDB) -> Dict:
                 "github_advisory": raw_data.get('github_advisory', {}),
                 "nvd_cpe": raw_data.get('nvd_cpe', []),
             })
+
+        # 대시보드에 남을 CVE인데 벤더가 비어 있으면 여기서 채운다. 마커·T3는 위에서
+        # 이미 반환됐고(affected를 저장하지도 않는다), should_alert는 방금
+        # enrich_threat_intel이 채웠다. 남는 건 '추적만 하는' CVE뿐이라 비용이 작다.
+        if not should_alert and _needs_cpe_lookup(current_state):
+            collector.fill_affected_from_nvd(raw_data)
+            current_state["affected"] = raw_data["affected"]
 
         # 여기 도달 = (1) 알림 대상(critical/자산high/에스컬레이션), 또는 (2) 추적 대상
         # (high 단독·자산 low). → 번역(Phase B, 배치)과 완성(Phase C)으로 넘긴다.

--- a/src/osv_index.py
+++ b/src/osv_index.py
@@ -20,6 +20,7 @@ Alpine secdb)와 GitHub Advisory를 정규화해 "이 CVE는 어느 패키지인
 import io
 import json
 import os
+import re
 import zipfile
 from typing import Dict, Iterable, List, Set
 
@@ -84,7 +85,20 @@ def _fixed_versions(aff: dict) -> List[str]:
     return sorted(out)
 
 
-_MAX_FIXED = 3   # 생태계당 보관할 수정 버전 수 — 크기 상한
+def _vkey(v: str):
+    """상한을 자를 때 쓰는 자연 정렬 키. 숫자 구간을 수치로 본다.
+
+    사전순으로 자르면 '가장 낮은 수정본'이 잘려나간다 — 실측으로 Tomcat
+    ['10.1.53','11.0.20','9.0.116']에서 9.0.116이 밀려났다. 판정하는 쪽은 그 최저값을
+    목표 버전으로 쓰므로 여기서 잘리면 안 된다. dpkg 완전 구현은 판정하는 쪽
+    (tools/sbom_match.py)에 있고, 여기서는 순서만 어긋나지 않으면 충분하다."""
+    return [(0, int(x)) if x.isdigit() else (1, x)
+            for x in re.split(r'(\d+)', str(v or '')) if x]
+
+
+# 생태계당 보관할 수정 버전 수. 여러 갈래를 함께 관리하는 제품(Tomcat 9/10/11,
+# Quarkus 3.8/3.15/3.18)은 갈래마다 수정본이 있어 3개로는 사용자의 갈래가 빠질 수 있다.
+_MAX_FIXED = 10
 
 
 def build_index(cve_ids: Iterable[str],
@@ -136,7 +150,7 @@ def build_index(cve_ids: Iterable[str],
                     # 76%가 빈 항목이라 파일이 34.9MB까지 불었다.
                     if not fixes:
                         continue
-                    merged = sorted(set(slot.get(pkg_eco) or []) | set(fixes))
+                    merged = sorted(set(slot.get(pkg_eco) or []) | set(fixes), key=_vkey)
                     slot[pkg_eco] = merged[:_MAX_FIXED]
                     hits += 1
         logger.info(f"  {eco}: 매칭 {hits:,}건")

--- a/tools/sbom_match.py
+++ b/tools/sbom_match.py
@@ -132,6 +132,13 @@ _TYPE_MAP = {"npm": "npm", "pypi": "PyPI", "python": "PyPI", "maven": "Maven",
              "golang": "Go", "go": "Go", "apk": "Alpine", "deb": "Debian"}
 
 
+def _series(v: str) -> str:
+    """버전의 갈래(major.minor). epoch(1:)와 리비전은 떼고 본다 — 1:9.0.116 → 9.0."""
+    up = split_deb(v)[1]
+    m = re.match(r"^(\d+\.\d+)", up)
+    return m.group(1) if m else ""
+
+
 def sbom_ecosystem(row: Dict) -> str:
     purl = str(row.get("purl") or "")
     m = _DISTRO.search(purl)
@@ -171,11 +178,22 @@ def version_verdict(installed: str, eco_map: Optional[Dict[str, List[str]]],
     if not fixes or not installed:
         return {"verdict": "unknown", "target": "", "eco": eco}
     try:
+        # 설치본과 같은 갈래(major.minor)의 수정본이 있으면 그것만 본다.
+        #
+        # 여러 갈래를 동시에 관리하는 제품이 흔하다 — Tomcat 9 / 10.1 / 11,
+        # Quarkus 3.8 / 3.15 / 3.18. OSV는 갈래별 수정본을 모두 주는데, 전체에서
+        # 최저값을 고르면 다른 갈래의 번호를 답으로 내놓게 된다. 그냥 틀린 답이
+        # 아니라 위험하다: Tomcat 10.1.40(취약)이 최저값 9.0.116보다 높다는 이유로
+        # '수정판'으로 판정돼, 고쳐야 할 것을 안전하다고 보고한다.
+        # 같은 갈래가 없으면(예: 8.5.x 사용 중인데 수정본은 9/10/11뿐) 전체를 본다.
+        branch = _series(installed)
+        same = [f for f in fixes if branch and _series(f) == branch]
+        pool = same or fixes
         # 하나라도 설치버전 이하면 이미 그 수정본을 넘어선 것
-        if any(cmp_version(installed, f) >= 0 for f in fixes):
+        if any(cmp_version(installed, f) >= 0 for f in pool):
             return {"verdict": "fixed", "target": "", "eco": eco}
         # 아직이면 가장 낮은 목표를 올릴 버전으로 제시
-        target = sorted(fixes, key=functools.cmp_to_key(cmp_version))[0]
+        target = sorted(pool, key=functools.cmp_to_key(cmp_version))[0]
         return {"verdict": "vulnerable", "target": target, "eco": eco}
     except Exception:
         return {"verdict": "unknown", "target": fixes[0], "eco": eco}
@@ -295,7 +313,6 @@ def build_results(cves: List[Dict], keys: Dict[str, Dict], pkg_index: Dict) -> L
     return out
 
 
-_SERIES = re.compile(r"^(\d+\.\d+)")
 _COLLAPSE_MIN = 20
 
 
@@ -313,14 +330,10 @@ def package_summary(pkg: str, rows: List[Dict]) -> str:
     vuln = [r for r in rows if r["verdict"] == "vulnerable"]
     installed = rows[0]["installed"]
     kev = sum(1 for r in rows if r["kev"])
-    m = _SERIES.match(installed or "")
+    branch = _series(installed or "")
     target = ""
-    if m:
-        same = []
-        for r in vuln:
-            t = _SERIES.match(r["target"] or "")
-            if t and t.group(1) == m.group(1):
-                same.append(r["target"])
+    if branch:
+        same = [r["target"] for r in vuln if _series(r["target"] or "") == branch]
         if same:
             target = sorted(same, key=functools.cmp_to_key(cmp_version))[-1]
     goal = f" → {target}" if target else ""


### PR DESCRIPTION
전수 점검에서 나온 것들. 첫 번째가 가장 위험하다 — 보안 도구가 취약한 자산을
안전하다고 보고하고 있었다.

1) 갈래(major.minor)를 무시한 버전 판정 [오탐지·심각]
   Tomcat 9 / 10.1 / 11처럼 여러 갈래를 함께 관리하는 제품은 OSV가 갈래마다
   수정본을 준다. 전체에서 최저값을 목표로 고르면 다른 갈래 번호를 답으로 내놓고,
   설치본이 그보다 높다는 이유로 '수정판'이 된다:
       Tomcat 10.1.40 (취약, 10.1.53 필요) → 최저값 9.0.116보다 높음 → '수정판 추정'
   설치본과 같은 갈래의 수정본이 있으면 그것만 보도록 고쳤다. 같은 갈래가 없으면
   (8.5.x인데 수정본이 9/10/11뿐) 종전대로 전체를 본다.

2) 상한을 사전순으로 잘라 최저 수정본이 사라짐
   merged[:3]이 사전순 정렬 뒤에 잘려 ['10.1.53','11.0.20','9.0.116']에서 9.0.116이
   밀려났다. 판정이 그 최저값을 목표로 쓰므로 잘리면 안 된다. 자연 정렬 키로 바꾸고
   상한을 10으로 올렸다(갈래가 여럿인 제품 대비).

3) CPE 보강이 CNA의 버전 범위를 파괴
   affected를 통째로 갈아끼우고 있었다. 벤더 없는 198건 중 119건이 제품명과 상세
   버전 범위를 갖고 있어서, 벤더 하나를 얻고 'versions=18 부터 18.5 이전, 17 부터
   17.11 이전...'을 '정보 없음'으로 바꾸는 거래였다. 제품명이 있는 항목은 그대로 두고
   벤더만 채우도록 병합으로 바꿨다. 제품명조차 없는 항목만 CPE 유래로 대체한다.

4) 마커로 끝날 CVE에 NVD 조회를 낭비
   벤더 조회를 티어 판정 앞에 뒀는데, 전체 감시 + 저위험은 마커로만 저장돼
   affected를 저장조차 하지 않는다. 조회를 '추적이 확정된 뒤'로 옮겼다. 알림 대상은
   enrich_threat_intel이 이미 채우므로, 남는 건 '추적만 하는' CVE뿐이다.

5) 배포 경로의 깨진 파일 위험
   데이터 파일을 더는 커밋하지 않으므로, 쓰다 만 JSON이 그대로 배포돼 대시보드가
   깨지고 다음 실행이 그걸 출발점으로 읽는다. export를 임시 파일+os.replace로
   원자화하고, 이어받기는 내려받은 JSON이 파싱되는지 확인한 뒤 저장하게 했다.

검증: cmp_version을 dpkg --compare-versions와 실제 버전 4,000쌍으로 대조(불일치 0). 갈래 판정 5케이스, affected 병합 7케이스, 원자적 쓰기, 차트·증분 병합 회귀, 대시보드 브라우저 12항목(콘솔 오류 0).


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd