### PR TITLE
fix: 백필이 대상의 3%만 보고 있었다 — PostgREST 행 상한에 잘림

### DIFF
--- a/src/backfill_published.py
+++ b/src/backfill_published.py
@@ -97,6 +97,9 @@ def main() -> int:
         return 1
 
     ok = db.bulk_set_published(rows, published)
+    if ok:
+        # updated_at을 건드리지 않으므로 증분 export가 이 변경을 못 본다 → 전량 1회 요청
+        db.request_full_export()
     logger.info("=" * 60)
     logger.info(f"백필 완료: {ok:,}/{len(targets):,}건 갱신")
     logger.info("=" * 60)

--- a/src/backfill_vendors.py
+++ b/src/backfill_vendors.py
@@ -94,6 +94,9 @@ def main() -> int:
             time.sleep(gap)
 
     ok = db.bulk_save_states(updates, "영향 벤더")
+    if ok:
+        # updated_at을 건드리지 않으므로 증분 export가 이 변경을 못 본다 → 전량 1회 요청
+        db.request_full_export()
     logger.info("=" * 60)
     logger.info(f"벤더 백필 완료: 복구 {hit:,} · NVD에도 없음 {miss:,} · 저장 {ok:,}건")
     if len(rows) > len(targets):

--- a/src/database.py
+++ b/src/database.py
@@ -444,23 +444,34 @@ class ArgusDB:
             logger.error(f"추적 CVE id 조회 실패: {e}")
         return ids
 
-    def _tracked_states(self, limit: int = 20000) -> List[Dict]:
-        """추적 행의 id + last_alert_state. 소급 백필의 공통 입력.
+    def _tracked_states(self, page_size: int = 1000, max_rows: int = 50000) -> List[Dict]:
+        """추적 행의 id + last_alert_state 전량. 소급 백필의 공통 입력.
+
+        반드시 range()로 페이지네이션한다. limit(20000)으로 한 번에 요청하면 PostgREST가
+        응답을 db-max-rows(Supabase 기본 1,000행)로 조용히 잘라, 최신 1,000건만 보게 된다.
+        실제로 그래서 벤더 백필이 대상 198건 중 7건만 보고 "완료"로 끝났다.
 
         JSONB 내부 조건(키 존재·배열 내부 값)은 서버 필터로 표현하기 번거로워
         호출부가 파이썬에서 거른다. 마커 행은 대시보드에 안 나오므로 제외한다."""
+        rows: List[Dict] = []
+        offset = 0
         try:
-            response = self._execute(
-                self.client.table("cves")
-                .select("id, last_alert_state")
-                .not_.is_("last_alert_state", "null")
-                .order("updated_at", desc=True)
-                .limit(limit)
-            )
-            return response.data or []
+            while offset < max_rows:
+                response = self._execute(
+                    self.client.table("cves")
+                    .select("id, last_alert_state")
+                    .not_.is_("last_alert_state", "null")
+                    .order("updated_at", desc=True)
+                    .range(offset, offset + page_size - 1)
+                )
+                batch = response.data or []
+                rows.extend(batch)
+                if len(batch) < page_size:
+                    break
+                offset += page_size
         except Exception as e:
-            logger.error(f"추적 행 조회 실패: {e}")
-            return []
+            logger.error(f"추적 행 조회 실패(부분 결과 {len(rows):,}건으로 진행): {e}")
+        return rows
 
     def get_rows_missing_published(self, limit: int = 20000) -> List[Dict]:
         """공개일(published)이 아직 없는 추적 행 — 소급 백필 대상."""
@@ -511,6 +522,16 @@ class ArgusDB:
         except Exception as e:
             logger.error(f"파이프라인 상태 저장 실패: {e}")
             return False
+
+    def request_full_export(self) -> bool:
+        """다음 export를 전량으로 돌리도록 표시한다.
+
+        백필은 '확인일'을 보존하려고 updated_at을 일부러 건드리지 않는다. 그런데 증분
+        export는 updated_at으로 바뀐 행을 찾으므로, 그대로 두면 백필 결과가 대시보드에
+        영영 나타나지 않는다. 한 번만 전량으로 돌려 반영시킨다."""
+        state = self.get_pipeline_state() or {}
+        state["force_full_export"] = True
+        return self.set_pipeline_state(state)
 
     _STATE_CHUNK = 200
 

--- a/src/export_dashboard_data.py
+++ b/src/export_dashboard_data.py
@@ -212,6 +212,24 @@ def export_cves(client, days: int = 90, since: str = None) -> list:
 _FULL_EXPORT_MAX_AGE_H = 24
 
 
+def _take_full_export_flag(client) -> bool:
+    """백필이 남긴 '전량 export 요청' 표시를 읽고 지운다.
+
+    백필은 '확인일'을 보존하려고 updated_at을 건드리지 않는데, 증분 export는 그 컬럼으로
+    바뀐 행을 찾는다. 표시가 없으면 백필 결과가 대시보드에 영영 나타나지 않는다."""
+    try:
+        r = client.table("pipeline_state").select("state").eq("id", 1).limit(1).execute()
+        st = ((r.data or [{}])[0] or {}).get("state") or {}
+        if not st.get("force_full_export"):
+            return False
+        st.pop("force_full_export", None)
+        client.table("pipeline_state").upsert({"id": 1, "state": st}).execute()
+        return True
+    except Exception as e:
+        print(f"  전량 export 표시 확인 실패(무시): {e}", flush=True)
+        return False
+
+
 def _fetch_live_export() -> tuple:
     """지금 배포돼 있는 cves.json·stats.json. 못 받으면 (None, None).
 
@@ -504,7 +522,11 @@ def main():
 
     # CVE 데이터 — 직전 결과가 쓸 만하면 바뀐 행만 가져와 병합한다(증분).
     print("[1/4] CVE 데이터 export...", flush=True)
-    previous, since = load_previous_export(data_dir)
+    if _take_full_export_flag(client):
+        print("  백필 반영 요청 있음 → 이번은 전량 export", flush=True)
+        previous, since = None, None
+    else:
+        previous, since = load_previous_export(data_dir)
     if previous is None:
         cve_data = export_cves(client)
         print(f"  전량 export: {len(cve_data)}건", flush=True)


### PR DESCRIPTION
사용자가 백필을 돌렸는데 대시보드 숫자가 그대로였다. 로그가 원인을 말해준다:

    대상 7건 중 이번 실행 7건 (예상 0분)
    벤더 백필 완료: 복구 0 · NVD에도 없음 7 · 저장 0건

대시보드에는 벤더 없는 행이 198건인데 백필은 7건만 봤다. _tracked_states가 limit(20000)으로 한 번에 요청하는데, PostgREST가 응답을 db-max-rows(Supabase 기본 1,000행)로 조용히 자른다. 그래서 '최신 1,000건' 안에서만 후보를 찾고 있었다. 공개일 백필도 같은 이유로 11,669건 중 30여 건만 채우고 끝났다(2.4% → 2.7%).

같은 파일의 get_tracked_ids·export_cves는 이미 range()로 페이지네이션하고 있었는데 _tracked_states만 limit()을 썼다. range()로 맞췄다.

두 번째 문제: 백필 결과가 대시보드에 영영 안 나타난다.
백필은 '확인일'을 보존하려고 updated_at을 일부러 건드리지 않는데, 증분 export는 바로 그 컬럼으로 바뀐 행을 찾는다. 두 결정이 서로를 무력화하고 있었다. 백필이
pipeline_state에 force_full_export 표시를 남기고, 다음 export가 그것을 읽고 지우며 한 번만 전량으로 도는 방식으로 연결했다.

검증: 2,350행을 3페이지로 전량 조회(예전 코드는 1,000에서 잘림), 전량 export 표시가 한 번만 소비되는지, 기존 회귀(차트·증분 병합·갈래 판정·affected 병합·원자적 쓰기· 배치 저장) 전부.

이 버그는 스텁 테스트로는 잡히지 않았다 — 스텁이 요청한 만큼 돌려주기 때문이다.
실제 DB의 응답 상한은 운영 로그를 보고서야 드러났다.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd