### PR TITLE
feat: 분석을 3.5로 올리고 Groq를 걷어냄 — 역할별 2단 + 정형 폴백으로 정리

### DIFF
--- a/.github/workflows/argus.yml
+++ b/.github/workflows/argus.yml
@@ -1,11 +1,17 @@
 name: Argus CVE Monitor
  
 on:
-  # 스케줄 일시 중지 — Groq/Gemini 일일 한도(TPD/RPD) 보존을 위해 자동 실행을 멈춘다.
-  # 자산 기준 티어링 반영·테스트 후 아래 두 줄 주석을 해제해 재개.
   schedule:
      - cron: '18 * * * *'  # 매시 18분 자동 실행
   workflow_dispatch:  # 수동 실행 가능 (테스트용으로 유지)
+    inputs:
+      full_export:
+        # 평소 export는 증분이다 — updated_at이 바뀐 행만 다시 그린다. 백필처럼
+        # updated_at을 건드리지 않는 변경이나 export 코드 자체가 바뀐 경우에는
+        # 손대지 않은 행이 옛 모습 그대로 남으므로, 한 번은 전량으로 다시 그려야 한다.
+        description: '전량 export (증분 대신 90일 전체를 다시 생성)'
+        type: boolean
+        default: false
  
 permissions:
   contents: read      # 데이터 파일을 더는 커밋하지 않는다 (Pages 아티팩트로 배포)
@@ -53,7 +59,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
@@ -70,6 +75,8 @@ jobs:
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # 스케줄 실행에서는 inputs가 비어 '0'이 된다 (증분 유지)
+          ARGUS_FULL_EXPORT: ${{ inputs.full_export && '1' || '0' }}
         run: python src/export_dashboard_data.py
 
       # 배포는 사이트 전체를 갈아끼운다. 이 잡이 만들지 않은 파일(주 1회 생성되는

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -21,7 +21,9 @@ on:
           - backfill-published # CVE 공개일 소급 (한 번만 돌리면 됨)
           - backfill-vendors   # 영향 벤더 소급 (NVD CPE로 n/a 복구)
       backfill_days:
-        description: '공개일 백필 소급 기간(일)'
+        # 30일씩 끊어 NVD를 조회한다. 키가 없으면 창당 8초라 7000일이면 ~30분 —
+        # 잡 타임아웃(60분) 안이지만, NVD_API_KEY가 있으면 훨씬 빠르다.
+        description: '공개일 백필 소급 기간(일) — 2024년 이전까지 채우려면 7000'
         default: '400'
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -286,22 +286,21 @@ CVSS 7점대가 하루 수백 건이라 점수만으로는 순서가 정해지�
 
 ## AI 스택
 
-일일 예산에 여유가 크고 출력 형식이 안정적인 모델을 주력으로 두고, 한도가 차거나 장애가 나면
-다른 공급자로 넘깁니다. 분석 품질은 평균보다 **편차**가 중요합니다 — 어제와 오늘의 리포트가
-다른 모델에서 나오면 기준이 흔들리기 때문입니다.
+분석 품질은 평균보다 **편차**가 중요합니다 — 어제와 오늘의 리포트가 다른 모델에서 나오면
+기준이 흔들리기 때문입니다. 그래서 **역할마다 모델을 2단으로** 두고, 앞 모델이 한도에 걸리거나
+서버 오류를 내면 같은 역할의 다음 모델이 이어받습니다. 한도는 모델별로 따로 잡히므로 앞이
+소진돼도 뒤는 그대로 남아 있습니다.
 
-운영해 보니 Groq는 일일 토큰 한도가 자주 차서 같은 성격의 CVE라도 날마다 다른 모델이 분석했고,
-자유 출력이라 형식이 깨지면 티어가 갈렸습니다. 그래서 주력을 JSON 모드가 되는 쪽으로 옮기고
-Groq는 비상용으로 남겼습니다. 공급자를 둘로 유지하는 것 자체가 목적입니다 — 한 곳이 멈춰도
-분석이 계속되어야 하니까요.
+| 용도 | 모델 | 비고 |
+|---|---|---|
+| **심층 분석** | `gemini-3.5-flash-lite` → `gemini-3.1-flash-lite` | JSON 모드로 구조화 출력 보장. 분석 대상이 Critical뿐이라 하루 6~30건 — RPD 500에 여유가 큽니다 |
+| **한국어 번역** | `gemma-4-31b-it` → `gemma-4-26b-a4b-it` | CVE 제목·설명 요약. 분석과 다른 모델이라 예산을 나눠 쓰지 않습니다 |
 
-| 용도 | 모델 | 공급자 | 비고 |
-|---|---|---|---|
-| **심층 분석 (주)** | `gemini-3.1-flash-lite` | Google AI Studio | JSON 모드로 구조화 출력 보장. 일일 예산에 여유가 커 결과가 일정합니다 |
-| **심층 분석 (비상)** | `gpt-oss-120b` → `qwen3.6-27b` | Groq | 주력 소진·장애 시 폴백. 앞 모델 한도 소진 시 다음 모델로 캐스케이드 |
-| **한국어 번역** | `gemma-4-31b-it` | Google AI Studio | CVE 제목·설명 요약 (분석과 예산 분리) |
+두 단계가 모두 불가하면 **정형 폴백**으로 내려갑니다 — 분석은 안내문, 번역은 영문 원문으로
+리포트가 나가고, 번역은 다음 실행의 백필이 회수합니다. 공급자가 통째로 멈춰도 파이프라인은
+계속 돌고 유실이 아니라 지연으로 흡수됩니다.
 
-> AI API 키(Groq · Google AI Studio)는 **이용자가 직접 발급**해 GitHub Secrets에 등록합니다.
+> AI API 키(Google AI Studio)는 **이용자가 직접 발급**해 GitHub Secrets에 등록합니다.
 > 무료 티어 한도 내 사용을 전제로 설계했으며, 각 AI 서비스의 이용약관은 이용자 책임하에 준수해야 합니다.
 
 ---
@@ -369,7 +368,6 @@ Argus가 사용하는 모든 외부 데이터와 그 라이선스입니다. **�
 
 | Secret | 발급처 | 필수 |
 |---|---|:--:|
-| `GROQ_API_KEY` | [console.groq.com](https://console.groq.com) | ✅ |
 | `GEMINI_API_KEY` | [aistudio.google.com](https://aistudio.google.com) | ✅ |
 | `SUPABASE_URL` · `SUPABASE_KEY` | [supabase.com](https://supabase.com) | ✅ |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook | ✅ |
@@ -409,7 +407,7 @@ insert into pipeline_state (id, state) values (1, '{}'::jsonb)
 ## 운영 비용
 
 개인이나 소규모 팀이 별도 서버 없이 운영할 수 있도록 전부 무료 티어 안에서 돌아가게 만들었습니다.
-실행은 GitHub Actions, 대시보드는 GitHub Pages, DB는 Supabase, AI는 Groq와 Google AI Studio를 씁니다.
+실행은 GitHub Actions, 대시보드는 GitHub Pages, DB는 Supabase, AI는 Google AI Studio를 씁니다.
 
 한도를 지키려고 상세 분석 리포트는 DB가 아니라 GitHub Issue에 남기고, DB에는 대시보드 표시와 재알림
 판단에 필요한 최소 정보만 넣습니다. 외부 API 호출량은 한도 관리자가 미리 조절합니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests
 google-genai
-groq
 supabase
 pytz
 tenacity

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2,7 +2,6 @@ import os
 import re
 import json
 import time
-from groq import Groq
 from google import genai
 from google.genai import types as genai_types
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -17,146 +16,76 @@ class AnalyzerError(Exception):
 
 class Analyzer:
     def __init__(self):
-        api_key = os.environ.get("GROQ_API_KEY")
-        if not api_key:
-            raise AnalyzerError("GROQ_API_KEY not found")
-
-        self.client = Groq(api_key=api_key)
-        # 3단 비상 폴백용 Gemini 클라이언트 (다른 공급자 — Groq 장애도 커버).
-        # HTTP 타임아웃 120초 — 행 방지 (실패는 fallback 분석이 흡수).
+        # HTTP 타임아웃 120초 — 행 방지 (실패는 정형 폴백이 흡수).
         gemini_key = os.environ.get("GEMINI_API_KEY")
-        self.gemini_client = None
-        if gemini_key:
-            try:
-                self.gemini_client = genai.Client(
-                    api_key=gemini_key,
-                    http_options=genai_types.HttpOptions(timeout=120_000),
-                )
-            except Exception:
-                self.gemini_client = genai.Client(api_key=gemini_key)
-        logger.info(f"Analyzer initialized (주력 {config.GEMINI_ANALYSIS_MODEL} "
-                    f"+ 비상 {config.GROQ_MODELS})")
-    
+        if not gemini_key:
+            raise AnalyzerError("GEMINI_API_KEY not found")
+        try:
+            self.gemini_client = genai.Client(
+                api_key=gemini_key,
+                http_options=genai_types.HttpOptions(timeout=120_000),
+            )
+        except Exception:
+            self.gemini_client = genai.Client(api_key=gemini_key)
+        logger.info(f"Analyzer initialized ({config.GEMINI_ANALYSIS_MODEL} "
+                    f"→ {config.GEMINI_ANALYSIS_FALLBACK_MODEL} → 정형 폴백)")
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=30)
     )
     def analyze_cve(self, cve_data: Dict) -> Dict:
-        """CVE 심층 분석. 주력 Gemini flash-lite → 비상 Groq 캐스케이드 → 폴백.
+        """CVE 심층 분석. 3.5 → 3.1 → 정형 폴백.
 
-        주력을 Gemini로 두는 이유(실측):
-          · 물량 — 분석은 Critical에만 하므로 백로그 소진 후 하루 6~30건. flash-lite의
-            일일 예산(RPD 1,000)에 30배 여유가 있어 소진되지 않는다. 반면 Groq는
-            TPD 200K×2가 자주 바닥나 같은 CVE라도 날마다 다른 모델이 분석했다.
-          · 출력 안정성 — flash-lite는 JSON 모드를 지원해 구조화 출력이 보장된다.
-            Groq 경로는 자유 출력이라 파싱 실패 시 다음 모델로 넘어가야 했다.
-
-        Groq를 없애지 않는 이유: Google AI Studio 장애 시 분석이 통째로 멈춘다.
-        공급자를 둘로 유지하는 것이 이중화의 목적이다(불변 원칙 5).
-        (compound 계열은 기반 모델 TPD를 공유 소모해 예산 이득이 없어 제외 — config 참조.)"""
+        두 모델은 한도가 따로 잡히므로(각 RPD 500) 앞이 소진돼도 뒤가 살아 있다.
+        둘 다 불가하면 정형 폴백으로 내려간다 — 리포트는 나가되 분석란이 안내문이
+        되고, 워터마크가 붙잡지 않으므로 그 CVE는 이 실행에서 마무리된다."""
         logger.info(f"Analyzing {cve_data['id']} with AI...")
         prompt = self._build_analysis_prompt(cve_data)
-        base = config.GROQ_ANALYSIS_PARAMS
 
-        # 1단(주력): Gemini flash-lite
-        result = self._analyze_with_gemini(cve_data, prompt)
-        if result is not None:
-            return result
-
-        # 2단(비상): 다른 공급자 — Groq 캐스케이드
-        logger.warning(f"{cve_data['id']}: Gemini 주력 불가 → Groq 비상 티어 시도")
-        for model in config.GROQ_MODELS:
-            # 이 모델 일일 한도(RPD/TPD) 소진이면 다음 모델로
-            if rate_limit_manager.is_tpd_exhausted(model, required_tokens=6000):
-                continue
-            try:
-                rate_limit_manager.check_and_wait("groq")
-
-                api_params = {
-                    "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "temperature": base["temperature"],
-                    "top_p": base["top_p"],
-                    "max_completion_tokens": base["max_completion_tokens"],
-                }
-                # reasoning 파라미터는 모델별로 다름 (gpt-oss=low, qwen=none)
-                reasoning = config.GROQ_MODEL_REASONING.get(model, {})
-                if reasoning.get("reasoning_effort"):
-                    api_params["reasoning_effort"] = reasoning["reasoning_effort"]
-                if reasoning.get("reasoning_format"):
-                    api_params["reasoning_format"] = reasoning["reasoning_format"]
-
-                response = self.client.chat.completions.create(**api_params)
-
-                tokens_used = 0
-                if hasattr(response, 'usage') and response.usage:
-                    tokens_used = response.usage.total_tokens
-                rate_limit_manager.record_call("groq", tokens_used=tokens_used, model=model)
-
-                raw_content = (response.choices[0].message.content or "").strip()
-                result = self._extract_json(raw_content)
-
-                if result is None or not self._validate_analysis_result(result):
-                    # 파싱/검증 실패 → 다음 모델로 재시도 (모델 이상 출력 대비 안전장치)
-                    logger.warning(f"{cve_data['id']}: AI 응답 파싱/검증 실패 ({model}) → 다음 모델 시도")
-                    continue
-
-                logger.info(f"{cve_data['id']}: Analysis complete (model={model})")
+        for model, limiter_key in (
+            (config.GEMINI_ANALYSIS_MODEL, "gemini_analysis"),
+            (config.GEMINI_ANALYSIS_FALLBACK_MODEL, "gemini_analysis_fb"),
+        ):
+            result = self._analyze_with_gemini(cve_data, prompt, model, limiter_key)
+            if result is not None:
                 return result
+            logger.warning(f"{cve_data['id']}: {model} 분석 불가 → 다음 단계")
 
-            except Exception as e:
-                error_str = str(e)
-                if "429" in error_str or "rate_limit" in error_str.lower():
-                    # 일일 한도(TPD/RPD) 소진 → 이 모델 마킹 후 다음 모델
-                    if any(t in error_str.lower() for t in ("tokens per day", "tpd", "requests per day", "rpd", "per day")):
-                        logger.warning(f"{model} 일일 한도 429 → 다음 모델 전환")
-                        rate_limit_manager.handle_429("groq", error_message=error_str, model=model)
-                        continue
-                    # 분/RPM 429 → 대기 후 tenacity 재시도
-                    retry_after = rate_limit_manager.parse_retry_after(error_str)
-                    wait_time = retry_after if retry_after else 10
-                    logger.warning(f"Groq 429 (RPM/TPM), {wait_time:.1f}초 대기 후 재시도")
-                    rate_limit_manager.handle_429("groq", wait_time, error_message=error_str, model=model)
-                    raise
-                # 네트워크/타임아웃 → tenacity 재시도
-                if any(k in error_str.lower() for k in ['timeout', 'connection', 'socket', 'network']):
-                    logger.warning(f"{cve_data['id']}: 일시적 에러, 재시도: {e}")
-                    raise
-                # 그 외(모델별 파라미터 미지원 등) → 다음 모델 시도
-                logger.warning(f"{cve_data['id']}: 분석 오류 ({model}: {e}) → 다음 모델 시도")
-                continue
-
-        # 두 공급자 모두 불가 → 정형 폴백(리포트는 나가되 분석란은 안내문)
         return self._fallback_analysis(cve_data)
 
-    # 주력 경로의 일시 오류 재시도 횟수. 무한정 붙들면 Groq 폴백이 늦어지므로 짧게.
+    # 한 모델에서의 일시 오류 재시도 횟수. 무한정 붙들면 다음 단계가 늦어지므로 짧게.
     _GEMINI_ATTEMPTS = 3
 
-    def _analyze_with_gemini(self, cve_data: Dict, prompt: str) -> Optional[Dict]:
-        """주력 분석 — Google AI Studio flash-lite. 번역(Gemma 31B)과 다른 모델이라
-        AI Studio 한도를 나눠 쓰지 않는다. JSON 모드로 구조화 출력을 강제. 실패 시 None.
+    def _analyze_with_gemini(self, cve_data: Dict, prompt: str,
+                             model: str, limiter_key: str) -> Optional[Dict]:
+        """지정한 flash-lite 모델로 분석. 실패하면 None(호출부가 다음 단계로 넘긴다).
 
-        일시 오류(503·분당 한도)는 여기서 재시도한다. 예전엔 비상 티어라 한 번 실패하면
-        바로 폴백했지만, 주력이 된 지금은 구글의 몇 초짜리 혼잡 때문에 그 CVE만 다른
-        모델이 분석해 리포트 품질이 들쭉날쭉해진다. 일일 한도 소진(rpd)만은 기다려도
-        풀리지 않으므로 즉시 마킹하고 넘긴다."""
-        model = getattr(config, "GEMINI_ANALYSIS_MODEL", None)
+        JSON 모드로 구조화 출력을 강제해 비정형 출력에 의한 파싱 실패를 막는다.
+        일시 오류(503·분당 한도)는 여기서 재시도한다 — 구글의 몇 초짜리 혼잡 때문에
+        그 CVE만 다른 모델이 분석하면 리포트 품질이 들쭉날쭉해진다. 일일 한도 소진
+        (rpd)은 기다려도 풀리지 않으므로 즉시 마킹하고 넘긴다.
+
+        limiter_key가 모델마다 다른 이유: AI Studio 한도는 모델별로 따로 잡히므로
+        3.5가 소진돼도 3.1은 멀쩡하다. 한 키를 공유하면 멀쩡한 쪽까지 잠긴다."""
         if not self.gemini_client or not model:
             return None
-        if rate_limit_manager.is_rpd_exhausted("gemini_analysis"):
-            logger.warning(f"{cve_data['id']}: Gemini 일일 한도 소진 → Groq로 전환")
+        if rate_limit_manager.is_rpd_exhausted(limiter_key):
+            logger.warning(f"{cve_data['id']}: {model} 일일 한도 소진")
             return None
 
+        params = config.ANALYSIS_PARAMS
         for attempt in range(1, self._GEMINI_ATTEMPTS + 1):
             try:
-                if not rate_limit_manager.check_and_wait("gemini_analysis"):
+                if not rate_limit_manager.check_and_wait(limiter_key):
                     return None   # 위 is_rpd_exhausted와 별개로, 동시 실행 중 소진된 경우
                 response = self.gemini_client.models.generate_content(
                     model=model,
                     contents=prompt,
                     config=genai_types.GenerateContentConfig(
-                        temperature=0.3,
-                        max_output_tokens=4096,
+                        temperature=params["temperature"],
+                        top_p=params["top_p"],
+                        max_output_tokens=params["max_output_tokens"],
                         # flash-lite는 JSON 모드 지원 → 비정형 출력으로 인한 파싱 실패 차단
                         response_mime_type="application/json",
                         # 보안 분석 내용이 안전필터에 오차단되지 않게 (번역 경로와 동일 설정)
@@ -166,33 +95,33 @@ class Analyzer:
                         )]
                     ),
                 )
-                rate_limit_manager.record_call("gemini_analysis")
+                rate_limit_manager.record_call(limiter_key)
 
                 result = self._extract_json((response.text or "").strip())
                 if result is None or not self._validate_analysis_result(result):
                     # JSON 모드에서도 필수 키가 빠질 수 있다. 형식 문제는 재시도해도
-                    # 같은 결과일 확률이 높아 Groq로 넘긴다(다른 모델이 더 나은 답).
-                    logger.warning(f"{cve_data['id']}: Gemini 분석 파싱/검증 실패 → Groq로 전환")
+                    # 같은 결과일 확률이 높아 다음 모델로 넘긴다.
+                    logger.warning(f"{cve_data['id']}: {model} 파싱/검증 실패")
                     return None
                 logger.info(f"{cve_data['id']}: Analysis complete (model={model})")
                 return result
 
             except Exception as e:
                 kind = gemini_error_kind(str(e))
-                # 일간 quota 429 → 대기 무의미, 즉시 소진 마킹 (이후 CVE는 바로 Groq).
-                # 분당 한도 429는 마킹하지 않는다 — 소진 상태는 상태 파일로 실행 간에
-                # 유지되므로 오판하면 주력 분석이 최대 24시간 잠긴다.
+                # 일간 quota 429 → 대기 무의미, 즉시 소진 마킹 (이후 CVE는 바로 다음 모델).
+                # 분당 한도 429는 마킹하지 않는다 — 소진 상태는 DB로 실행 간에 유지되므로
+                # 오판하면 그 모델이 최대 24시간 잠긴다.
                 if kind == "rpd":
-                    rate_limit_manager.mark_rpd_exhausted("gemini_analysis")
-                    logger.warning(f"{cve_data['id']}: Gemini 일일 한도 소진 → Groq로 전환")
+                    rate_limit_manager.mark_rpd_exhausted(limiter_key)
+                    logger.warning(f"{cve_data['id']}: {model} 일일 한도 소진")
                     return None
                 if kind in ("rate", "transient") and attempt < self._GEMINI_ATTEMPTS:
                     wait = gemini_backoff(kind, attempt, str(e))
-                    logger.warning(f"{cve_data['id']}: Gemini {kind} 오류"
+                    logger.warning(f"{cve_data['id']}: {model} {kind} 오류"
                                    f"({attempt}/{self._GEMINI_ATTEMPTS}) → {wait:.0f}s 후 재시도")
                     time.sleep(wait)
                     continue
-                logger.warning(f"{cve_data['id']}: Gemini 분석 실패({kind}): {e} → Groq로 전환")
+                logger.warning(f"{cve_data['id']}: {model} 분석 실패({kind}): {e}")
                 return None
         return None
 

--- a/src/backfill_published.py
+++ b/src/backfill_published.py
@@ -13,7 +13,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Dict
+from typing import Dict, Tuple
 
 import requests
 
@@ -27,8 +27,11 @@ _GAP_NO_KEY, _GAP_KEY = 8.0, 0.7
 
 
 def _fetch_window(start: datetime.datetime, end: datetime.datetime,
-                  api_key: str) -> Dict[str, str]:
-    """NVD에서 [start, end) 공개 CVE의 {id: 공개일} 수집. 실패해도 예외 없이 빈 dict."""
+                  api_key: str) -> Tuple[Dict[str, str], bool]:
+    """NVD에서 [start, end) 공개 CVE의 {id: 공개일} 수집. ({id: 날짜}, 조회 성공 여부).
+
+    성공 여부를 함께 돌려주는 이유: '한 건도 못 채웠다'가 NVD 장애인지, 남은 대상이
+    조회 창 밖(오래된 CVE)일 뿐인지 구분해야 종료 코드를 옳게 낼 수 있다."""
     headers = {"apiKey": api_key} if api_key else {}
     out: Dict[str, str] = {}
     idx = 0
@@ -45,7 +48,7 @@ def _fetch_window(start: datetime.datetime, end: datetime.datetime,
             data = r.json()
         except (requests.exceptions.RequestException, ValueError) as e:
             logger.warning(f"  NVD 조회 실패 ({start:%Y-%m-%d}): {e}")
-            return out
+            return out, False
 
         for item in data.get("vulnerabilities", []) or []:
             cve = item.get("cve") or {}
@@ -58,7 +61,7 @@ def _fetch_window(start: datetime.datetime, end: datetime.datetime,
         if idx >= total:
             break
         time.sleep(_GAP_KEY if api_key else _GAP_NO_KEY)
-    return out
+    return out, True
 
 
 def main() -> int:
@@ -80,10 +83,13 @@ def main() -> int:
     now = datetime.datetime.now(datetime.timezone.utc)
     published: Dict[str, str] = {}
     step = 30
+    windows = fetched = 0
     for off in range(0, days, step):
         end = now - datetime.timedelta(days=off)
         start = now - datetime.timedelta(days=min(off + step, days))
-        got = _fetch_window(start, end, api_key)
+        got, ok_window = _fetch_window(start, end, api_key)
+        windows += 1 if ok_window else 0
+        fetched += len(got)
         hit = {k: v for k, v in got.items() if k in targets}
         published.update(hit)
         logger.info(f"  {start:%Y-%m-%d} ~ {end:%Y-%m-%d}: 수집 {len(got):,} · 우리 것 {len(hit):,} "
@@ -93,8 +99,15 @@ def main() -> int:
         time.sleep(_GAP_KEY if api_key else _GAP_NO_KEY)
 
     if not published:
-        logger.warning("채울 공개일을 하나도 못 받았습니다 — 저장 생략")
-        return 1
+        # 조회 자체가 안 됐으면 실패(빨간 X가 맞다). 조회는 됐는데 겹치는 게 없으면
+        # 남은 대상이 창 밖(오래된 CVE)이라는 뜻이라 실패가 아니다 — 창을 넓히면 된다.
+        if windows == 0 or fetched == 0:
+            logger.warning("NVD에서 아무것도 받지 못했습니다 — 조회 실패")
+            return 1
+        logger.info(f"최근 {days}일 창에 해당하는 대상이 없습니다 "
+                    f"(NVD {fetched:,}건 조회 · 겹침 0). 남은 {len(targets):,}건은 더 과거의 "
+                    f"CVE이므로 BACKFILL_DAYS를 늘려 다시 실행하세요.")
+        return 0
 
     ok = db.bulk_set_published(rows, published)
     if ok:

--- a/src/config.py
+++ b/src/config.py
@@ -11,62 +11,44 @@ class ArgusConfig:
     # ==========================================
     # [1] AI 모델 설정
     # ==========================================
-    MODEL_PHASE_0 = "gemma-4-31b-it"  # 빠른 번역/요약 (Google AI Studio / Gemini API)
-    MODEL_PHASE_1 = "gemini-3.1-flash-lite"  # 심층 분석 주 모델 (Google AI Studio)
-
-    # 심층 분석 주력 — Google AI Studio flash-lite.
-    # 주력으로 둔 근거(실측): 분석은 Critical에만 하므로 하루 6~30건인데 RPD 1,000이라
-    # 30배 여유다. Groq는 TPD 200K×2가 자주 바닥나 같은 성격의 CVE라도 날마다 다른
-    # 모델이 분석했다. 추론 깊이는 gpt-oss보다 낮지만 JSON 모드로 구조화 출력이
-    # 보장돼 파싱 실패로 티어가 갈리는 일이 없다 — 품질의 평균보다 편차가 중요하다.
-    # 번역(Gemma 31B)과 다른 모델이라 AI Studio 한도(모델별)를 나눠 쓰지 않는다.
-    GEMINI_ANALYSIS_MODEL = "gemini-3.1-flash-lite"
-
-    # 심층 분석 비상 티어 — 주력(Gemini)이 소진·장애일 때만 사용.
-    # 없애지 않는 이유: 공급자가 하나면 Google AI Studio 장애에 분석이 통째로 멈춘다.
-    # 공급자를 둘로 유지하는 것이 이중화의 목적이다(불변 원칙 5).
+    # AI는 Google AI Studio 하나만 쓴다. 모델은 각 역할마다 2단이고, 둘 다 불가하면
+    # 정형 폴백(_fallback_analysis / 영문 원문)으로 내려가 파이프라인은 계속 돈다.
     #
-    # 앞 모델의 일일 한도(TPD)가 소진되면 다음 모델로 자동 전환.
-    # gpt-oss-120b와 qwen3.6은 TPD 200K/일이 '각각' 잡혀 실질 일일 예산 400K.
+    #   분석  gemini-3.5-flash-lite  →  gemini-3.1-flash-lite  →  정형 폴백
+    #   번역  gemma-4-31b-it         →  gemma-4-26b-a4b-it     →  영문 원문
     #
-    # ⚠️ compound/compound-mini는 제외한다: agentic 시스템이라 내부적으로 기반 모델
-    # (gpt-oss-120b 등)을 호출하며, 토큰이 '기반 모델의 TPD'로 계상된다(429 로그로 확인:
-    # compound 요청이 openai/gpt-oss-120b TPD 200K 한도에 걸림). 즉 예산이 합산되지 않고
-    # 오히려 웹검색 컨텍스트만큼 같은 예산을 더 빨리 소모 + 다단계 실행으로 지연 + 비정형
-    # 출력으로 파싱 재시도까지 유발 → 캐스케이드에 넣을 이유가 없다.
-    GROQ_MODELS = [
-        "openai/gpt-oss-120b",
-        "qwen/qwen3.6-27b",
-    ]
+    # 공급자를 하나로 좁힌 대신 역할마다 모델을 2단으로 둔다. 이유는 도달률이다 —
+    # 분석은 Critical만이라 하루 6~30건인데 RPD가 500이라 1단이 소진될 일이 거의 없고,
+    # 소진되더라도 같은 역할의 다른 모델이 이어받는다(한도는 모델별로 따로 잡힌다).
+    # 최종 안전망은 정형 폴백이다. 공급자가 통째로 죽어도 리포트는 나가고 워터마크가
+    # 붙잡아 다음 실행에서 재처리된다 — 유실이 아니라 지연이다. 대신 그동안 분석란은
+    # 안내문으로 나간다(불변 원칙 5: 단일 공급자 + 역할별 2단 + 정형 폴백).
 
-    # 모델별 일일 소진 기준. rpd=요청 수/일, tpd=토큰 수/일. None=해당 기준 무제한.
-    GROQ_MODEL_LIMITS = {
-        "openai/gpt-oss-120b": {"rpd": None, "tpd": 200_000},
-        "qwen/qwen3.6-27b":    {"rpd": None, "tpd": 200_000},
-    }
+    # 번역 — Gemma. 한도는 모델마다 별도로 잡힌다(31B 소진이 26B에 영향 없음).
+    MODEL_PHASE_0 = "gemma-4-31b-it"
+    MODEL_PHASE_0_FALLBACK = "gemma-4-26b-a4b-it"
 
-    # 심층 분석 공통 파라미터 (temp/top_p/max는 모델 공통). TPM이 250K로 상향되어 8K 제약이
-    # 사라졌으므로 출력 상한을 넉넉히(4096) 둔다. reasoning은 모델별로 GROQ_MODEL_REASONING에서 지정.
-    GROQ_ANALYSIS_PARAMS = {
+    # 심층 분석 — flash-lite. 3.5가 후속 모델이고 한도는 3.1과 동일(RPM 15 / TPM 250K /
+    # RPD 500)이라 교체해도 예산 구조가 바뀌지 않는다.
+    # 번역(Gemma)과 다른 모델이라 AI Studio 한도를 나눠 쓰지 않는다.
+    MODEL_PHASE_1 = "gemini-3.5-flash-lite"
+    GEMINI_ANALYSIS_MODEL = "gemini-3.5-flash-lite"
+    GEMINI_ANALYSIS_FALLBACK_MODEL = "gemini-3.1-flash-lite"
+
+    # 심층 분석 공통 파라미터. JSON 모드로 구조화 출력이 보장돼 파싱 실패로 티어가
+    # 갈리는 일이 없다 — 품질의 평균보다 편차가 중요하다.
+    ANALYSIS_PARAMS = {
         "temperature": 0.3,  # 일관된 출력 (hallucination 감소)
         "top_p": 0.9,
-        "max_completion_tokens": 4096,
+        "max_output_tokens": 4096,
     }
-
-    # 모델별 reasoning 파라미터 — 모델마다 지원값이 다르다. 값이 없으면(빈 dict) API 호출에서 생략.
-    #   gpt-oss-120b: "low"(최소 추론) / qwen3.6: "none"(비추론). reasoning_format="parsed"로 JSON 보호.
-    GROQ_MODEL_REASONING = {
-        "openai/gpt-oss-120b": {"reasoning_effort": "low", "reasoning_format": "parsed"},
-        "qwen/qwen3.6-27b": {"reasoning_effort": "none", "reasoning_format": "parsed"},
-    }
-
 
     # ==========================================
     # [2] 성능 최적화 설정
     # ==========================================
     PERFORMANCE = {
-        # TPM이 250K로 상향되어 병렬 워커의 8K TPM 429 폭주 위험이 사라짐 → 병렬 복원.
-        # (Groq RPM 30 + 고위험당 분석 1회라 병렬로도 RPM 여유. 저위험 fetch 병렬화로 처리량↑.)
+        # 분석 TPM 250K에 고위험당 분석 1회라 병렬로도 분당 한도에 여유가 있다.
+        # 저위험 fetch 병렬화로 처리량을 올린다.
         "max_workers": 4,
         "rule_check_interval_days": 7,  # 공식 룰 재확인 주기
         # 실행당 처리 상한. 자산 기준 티어링으로 비자산 저위험(유입의 대부분)은 번역 없이
@@ -122,7 +104,6 @@ class ArgusConfig:
         "SUPABASE_URL",
         "SUPABASE_KEY",
         "SLACK_WEBHOOK_URL",
-        "GROQ_API_KEY",
         "GEMINI_API_KEY"
     ]
     

--- a/src/main.py
+++ b/src/main.py
@@ -403,6 +403,18 @@ def _needs_cpe_lookup(cve_data: Dict) -> bool:
         for a in (cve_data.get('affected') or [])
     )
 
+# 번역 2단. 한도는 모델마다 따로 잡히므로 31B가 소진돼도 26B는 그대로 남아 있다 —
+# 앞 모델이 한도/서버 문제로 못 하면 뒤 모델이 이어받고, 둘 다 안 되면 영문 원문이다.
+_TRANSLATION_STAGES = (
+    (config.MODEL_PHASE_0, "gemini"),
+    (config.MODEL_PHASE_0_FALLBACK, "gemini_fb"),
+)
+
+# 다음 모델로 넘길 사유. 한도·서버 문제는 모델이 바뀌면 풀릴 수 있지만, 안전 차단이나
+# 잘못된 요청("other")은 같은 프롬프트로 같은 결과가 나온다 — 넘겨봐야 호출만 태운다.
+_TR_STAGE_ADVANCE = ("skip", "rate", "transient")
+
+
 def generate_korean_summary(cve_data: Dict, retry_on_transient: bool = False) -> Tuple[str, str]:
     """CVE 제목/설명을 한국어로 번역. 실패 시 영문 원본 폴백.
 
@@ -421,19 +433,36 @@ Do NOT add intro/outro.
 """
 
     fallback = (cve_data['title'], cve_data['description'][:200])
+    max_attempts = 3 if retry_on_transient else 1
 
+    reason = "skip"
+    for model, limiter_key in _TRANSLATION_STAGES:
+        out, reason = _translate_one(prompt, fallback, model, limiter_key, max_attempts)
+        if out is not None:
+            _tr_bump("ok")
+            return out
+        if reason not in _TR_STAGE_ADVANCE:
+            break
+    _tr_bump(_TR_REASON_KEY.get(reason, "en_other"))
+    return fallback
+
+
+def _translate_one(prompt: str, fallback: Tuple[str, str], model: str, limiter_key: str,
+                   max_attempts: int) -> Tuple[Optional[Tuple[str, str]], str]:
+    """단일 CVE를 모델 하나로 번역 시도. (결과, 사유)를 반환한다.
+
+    사유: "ok" · "skip"(일일 한도 소진) · "rate"/"transient"(다음 모델 가치 있음) ·
+          "other"(안전 차단·잘못된 요청 등 — 모델을 바꿔도 같다)."""
     # 무료 Gemma는 과부하 시 503(high demand)/500(INTERNAL) 같은 일시 서버 오류를 낸다.
     # 이는 우리 한도(429)가 아니라 구글 서버측 문제. 고위험만 백오프 재시도로 회복하고
     # 저위험은 즉시 폴백. 그 외(안전 차단·잘못된 요청 등)는 재시도해도 무의미.
-    max_attempts = 3 if retry_on_transient else 1
     for attempt in range(1, max_attempts + 1):
         try:
-            if not rate_limit_manager.check_and_wait("gemini"):
+            if not rate_limit_manager.check_and_wait(limiter_key):
                 # 일일 한도 소진 — 호출해봐야 429만 받는다
-                _tr_bump("en_rpd")
-                return fallback
+                return None, "skip"
             response = gemini_client.models.generate_content(
-                model=config.MODEL_PHASE_0,
+                model=model,
                 contents=prompt,
                 config=types.GenerateContentConfig(
                     # 번역은 짧음(제목 + 3줄). 출력 상한을 두지 않으면 gemma-4가
@@ -451,10 +480,10 @@ Do NOT add intro/outro.
             usage = getattr(response, "usage_metadata", None)
             if usage is not None:
                 gemini_tokens = getattr(usage, "total_token_count", 0) or 0
-            rate_limit_manager.record_call("gemini", tokens_used=gemini_tokens)
+            rate_limit_manager.record_call(limiter_key, tokens_used=gemini_tokens)
 
-            text = response.text.strip()
-            title_ko, desc_ko = cve_data['title'], cve_data['description'][:200]
+            text = (response.text or "").strip()
+            title_ko, desc_ko = fallback
 
             for line in text.split('\n'):
                 if line.startswith("제목:"):
@@ -462,8 +491,7 @@ Do NOT add intro/outro.
                 if line.startswith("내용:"):
                     desc_ko = line.replace("내용:", "").strip()
 
-            _tr_bump("ok")
-            return title_ko, desc_ko
+            return (title_ko, desc_ko), "ok"
 
         except Exception as e:
             msg = str(e)
@@ -471,20 +499,18 @@ Do NOT add intro/outro.
             if kind == "rpd":
                 # 공급자가 먼저 일일 소진을 알려줬다 = 우리 카운터가 실제보다 적게 셌다는 뜻.
                 # 소진으로 마킹해 이번 실행의 남은 번역이 429를 반복하지 않게 한다.
-                rate_limit_manager.mark_rpd_exhausted("gemini")
-                logger.warning("번역 일일 한도(RPD) 소진 — 이후 번역은 영문 폴백")
-                _tr_bump("en_rpd")
-                return fallback
+                rate_limit_manager.mark_rpd_exhausted(limiter_key)
+                logger.warning(f"번역 일일 한도(RPD) 소진: {model}")
+                return None, "skip"
             if kind in ("rate", "transient") and attempt < max_attempts:
                 wait = _gemini_backoff(kind, attempt, msg)
-                logger.warning(f"번역 {kind} 오류({attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
+                logger.warning(f"번역 {kind} 오류({model} {attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
                 time.sleep(wait)
                 continue
-            logger.warning(f"번역 실패({kind}): {e}, 원본 사용")
-            _tr_bump(f"en_{kind}")
-            return fallback
+            logger.warning(f"번역 실패({model} {kind}): {e}")
+            return None, kind
 
-    return fallback
+    return None, "transient"
 
 
 # 대기 규칙도 rate_limiter가 소유한다 — 분류(gemini_error_kind)와 같은 자리에 둬야
@@ -524,9 +550,12 @@ def _log_translation_summary() -> None:
     if not (ok or fallback):
         return
     breakdown = " · ".join(f"{label} {snap.get(key, 0)}" for key, label in _TR_LABELS)
-    used, limit = rate_limit_manager.rpd_status("gemini")
+    rpd = " · ".join(
+        f"{model} {u:,}/{l:,}"
+        for model, u, l in ((m,) + rate_limit_manager.rpd_status(k) for m, k in _TRANSLATION_STAGES)
+    )
     logger.info(f"🈯 번역 요약(누적): 한글 {ok}건 · 영문폴백 {fallback}건 "
-                f"({breakdown}) · Gemma RPD {used:,}/{limit:,}")
+                f"({breakdown}) · RPD {rpd}")
 
 
 def generate_korean_summaries_batch(items: List[Dict], high_risk_ids: set,
@@ -632,7 +661,10 @@ def _translate_chunk(chunk: List[Dict],
 
     사유: "ok"(성공) · "parse"(응답 형식 파손 → 개별 폴백 가치 있음) ·
           "api"(호출 실패 → 개별 폴백 무의미) · "skip"(일일 한도 소진)
-    응답 JSON에서 누락된 항목은 영문 폴백으로 채워 성공 시 반환값은 청크 전체를 커버한다."""
+    응답 JSON에서 누락된 항목은 영문 폴백으로 채워 성공 시 반환값은 청크 전체를 커버한다.
+
+    번역 2단(31B → 26B)은 개별 번역과 같은 규칙이다 — 한도/서버 문제면 뒤 모델이
+    이어받고, 형식 파손·안전 차단이면 모델을 바꿔도 같으므로 넘기지 않는다."""
     # 입력 500자·출력 2줄 요약으로 제한 — 배치당 생성 토큰을 줄여 호출당 소요를 절반 이하로
     # (관측: 출력이 크면 배치당 ~60초 → 40청크에 40분, 실행 타임아웃의 주범이었음)
     numbered = "\n".join(
@@ -648,12 +680,25 @@ Output EXACTLY one JSON array with {len(chunk)} objects in the same order, and n
 CVEs:
 {numbered}"""
     max_attempts = 3 if retry_on_transient else 1
+    reason = "skip"
+    for model, limiter_key in _TRANSLATION_STAGES:
+        out, reason = _translate_chunk_with(chunk, prompt, model, limiter_key, max_attempts)
+        if out is not None:
+            return out, "ok"
+        if reason not in _TR_STAGE_ADVANCE:
+            return None, reason
+    return None, reason
+
+
+def _translate_chunk_with(chunk: List[Dict], prompt: str, model: str, limiter_key: str,
+                          max_attempts: int) -> Tuple[Optional[Dict[str, Tuple[str, str]]], str]:
+    """청크를 모델 하나로 번역 시도. 사유는 _translate_chunk와 같은 어휘를 쓴다."""
     for attempt in range(1, max_attempts + 1):
         try:
-            if not rate_limit_manager.check_and_wait("gemini"):
+            if not rate_limit_manager.check_and_wait(limiter_key):
                 return None, "skip"
             response = gemini_client.models.generate_content(
-                model=config.MODEL_PHASE_0,
+                model=model,
                 contents=prompt,
                 config=types.GenerateContentConfig(
                     max_output_tokens=3072,  # 6건 × 제목+2줄 요약 — 잘림 방지(JSON 완결)
@@ -668,7 +713,7 @@ CVEs:
             usage = getattr(response, "usage_metadata", None)
             if usage is not None:
                 tokens = getattr(usage, "total_token_count", 0) or 0
-            rate_limit_manager.record_call("gemini", tokens_used=tokens)
+            rate_limit_manager.record_call(limiter_key, tokens_used=tokens)
 
             text = (response.text or "").strip()
             text = re.sub(r"```(?:json)?\s*\n?", "", text).strip()
@@ -700,15 +745,15 @@ CVEs:
             msg = str(e)
             kind = _gemini_error_kind(msg)
             if kind == "rpd":
-                rate_limit_manager.mark_rpd_exhausted("gemini")
-                logger.warning("일괄 번역 일일 한도(RPD) 소진 — 이후 번역은 영문 폴백")
+                rate_limit_manager.mark_rpd_exhausted(limiter_key)
+                logger.warning(f"일괄 번역 일일 한도(RPD) 소진: {model}")
                 return None, "skip"
             if kind in ("rate", "transient") and attempt < max_attempts:
                 wait = _gemini_backoff(kind, attempt, msg)
-                logger.warning(f"일괄 번역 {kind} 오류({attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
+                logger.warning(f"일괄 번역 {kind} 오류({model} {attempt}/{max_attempts}): {e} → {wait:.0f}s 후 재시도")
                 time.sleep(wait)
                 continue
-            logger.warning(f"일괄 번역 청크 실패({kind}): {e}")
+            logger.warning(f"일괄 번역 청크 실패({model} {kind}): {e}")
             return None, kind
     return None, "api"
 
@@ -1264,13 +1309,12 @@ def finalize_single_cve(prep: Dict, translation: Optional[Tuple[str, str]],
         report_url = None
         rules_info = None
         if should_alert and full_report:
-            # 분석 티어(Gemini 주력 + Groq 비상)가 전부 소진됐을 때만 Issue 보류.
-            # 한쪽만 소진이면 다른 쪽이 분석하므로 알림이 지연되지 않는다 — 그래서 조건이
-            # AND다(어느 쪽이 주력인지와 무관하게 '둘 다 불가'만 잡는다).
+            # 분석 2단(3.5 → 3.1)이 모두 소진일 때만 보류한다. 한쪽만 소진이면 다른 쪽이
+            # 분석하므로 알림이 지연되지 않는다 — 그래서 조건이 AND다.
             # 보류 시 Slack/DB저장 없이 failed로 반환해 워터마크가 붙잡고 다음 실행에서 완전 재처리
             # (Slack 미발송 → 중복알림 없음, content_hash 미저장 → 재수집됨 → 누락 없음).
-            if (rate_limit_manager.active_groq_model(config.GROQ_MODELS) is None
-                    and rate_limit_manager.is_rpd_exhausted("gemini_analysis")):
+            if (rate_limit_manager.is_rpd_exhausted("gemini_analysis")
+                    and rate_limit_manager.is_rpd_exhausted("gemini_analysis_fb")):
                 logger.warning(f"⚠️ {cve_id}: 분석 티어 전부 소진 → Issue 보류(다음 실행 재처리)")
                 return {"cve_id": cve_id, "status": "failed"}
             report_url, rules_info = create_github_issue(current_state, alert_reason)
@@ -1547,7 +1591,7 @@ def check_for_escalations(collector: Collector, db: ArgusDB, notifier: SlackNoti
         분석→Issue→Slack→저장). 재처리 안에서 최신 신호로 재판정하므로 알림/저장이 일관된다.
 
     재알림 중복은 없다: 승격이 성공 저장되면 last_alert_state가 갱신돼 다음 스윕에서 current==last가
-    되어 재트리거되지 않는다. Groq 소진 등으로 저장 전 실패하면 Slack도 안 나가고(게이트가
+    되어 재트리거되지 않는다. 분석 한도 소진 등으로 저장 전 실패하면 Slack도 안 나가고(게이트가
     Slack 이전에 조기 반환) last가 그대로라 다음 실행 스윕에서 자연히 재시도된다.
     """
     try:
@@ -1662,7 +1706,7 @@ def _main():
 
     # Step 4.5: 에스컬레이션 재평가 스윕 — 레코드 미변경으로 재수집 큐에 안 올라오는 저위험 CVE의
     # 외부 피드(KEV/EPSS/ExploitDB/Metasploit) 단독 변화 승격을 메운다. KEV 세트가 로드된 직후
-    # 실행해 승격 재알림이 신규 저위험 백로그보다 우선 Groq 예산을 확보하고 타임아웃 전에 완주하게 한다.
+    # 실행해 승격 재알림이 신규 저위험 백로그보다 우선 AI 예산을 확보하고 타임아웃 전에 완주하게 한다.
     check_for_escalations(collector, db, notifier)
 
     # 소프트 데드라인 — Actions timeout(45분)에 killed 되면 워터마크를 못 써 다음 실행이
@@ -1908,13 +1952,24 @@ def _main():
 
     success_count = sum(1 for s in status_by_id.values() if s == 'success')
 
-    # 분석 티어 소진 경고 — 주력(Gemini) 기준으로 본다
+    # 분석 티어 소진 경고
     if rate_limit_manager.is_rpd_exhausted("gemini_analysis"):
-        if rate_limit_manager.active_groq_model(config.GROQ_MODELS) is None:
-            logger.warning("🚫 분석 티어 전부(Gemini 주력 + Groq 비상) 소진 → "
+        if rate_limit_manager.is_rpd_exhausted("gemini_analysis_fb"):
+            logger.warning(f"🚫 분석 2단({config.GEMINI_ANALYSIS_MODEL} + "
+                           f"{config.GEMINI_ANALYSIS_FALLBACK_MODEL}) 모두 소진 → "
                            "일부 고위험 CVE 보류, 다음 실행에서 자동 재처리")
         else:
-            logger.warning("⚠️ Gemini 주력 RPD 소진 → 분석이 Groq 비상 티어로 수행됨")
+            logger.warning(f"⚠️ {config.GEMINI_ANALYSIS_MODEL} RPD 소진 → "
+                           f"분석이 {config.GEMINI_ANALYSIS_FALLBACK_MODEL}로 수행됨")
+
+    # 번역 티어 소진 경고 — 남은 영문은 다음 실행의 번역 백필이 회수한다
+    if rate_limit_manager.is_rpd_exhausted("gemini"):
+        if rate_limit_manager.is_rpd_exhausted("gemini_fb"):
+            logger.warning(f"🚫 번역 2단({config.MODEL_PHASE_0} + {config.MODEL_PHASE_0_FALLBACK}) "
+                           "모두 소진 → 잔여는 영문, 다음 실행 백필에서 회수")
+        else:
+            logger.warning(f"⚠️ {config.MODEL_PHASE_0} RPD 소진 → "
+                           f"번역이 {config.MODEL_PHASE_0_FALLBACK}로 수행됨")
 
     # Step 9: Slack 배치 요약 전송 (High 추적 건수 포함 — Issue 없이도 규모는 파악되게)
     repo = os.environ.get("GITHUB_REPOSITORY", "")

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -88,13 +88,6 @@ class RateLimitManager:
                 window_seconds=3600,
                 min_interval=0.5
             ),
-            # Groq Free Tier: RPM 30 (분당 요청). 일일 한도(TPD 200K)는
-            # gpt-oss/qwen 모델별로 별도 카운터로 추적.
-            "groq": RateLimitInfo(
-                limit=30,
-                window_seconds=60,
-                min_interval=2.0
-            ),
             "epss": RateLimitInfo(
                 limit=60,
                 window_seconds=60,
@@ -105,18 +98,33 @@ class RateLimitManager:
                 window_seconds=3600,
                 min_interval=2.0
             ),
-            # Gemma 4 Free Tier: RPM 15 / TPM 무제한 / RPD 1,500 (번역 전용)
+            # 아래 4개는 Google AI Studio 모델별 한도(콘솔 실측). 모델마다 따로 잡히므로
+            # 한 모델이 소진돼도 다른 모델은 멀쩡하다 — 그래서 키를 나눈다.
+            #
+            # 번역 Gemma 4 31B: RPM 30 / TPM 16K / RPD 14.4K. 실측 병목은 RPD(4%)가
+            # 아니라 TPM(76%)·RPM(87%)이라 min_interval로 분당 유입을 눌러 둔다.
             "gemini": RateLimitInfo(
+                limit=30,
+                window_seconds=60,
+                min_interval=2.0
+            ),
+            # 번역 폴백 Gemma 4 26B: RPM 30 / TPM 16K. 31B와 같은 등급으로 본다.
+            "gemini_fb": RateLimitInfo(
+                limit=30,
+                window_seconds=60,
+                min_interval=2.0
+            ),
+            # 분석 Gemini 3.5 Flash-Lite: RPM 15 / TPM 250K / RPD 500.
+            "gemini_analysis": RateLimitInfo(
                 limit=15,
                 window_seconds=60,
                 min_interval=4.0
             ),
-            # Gemini flash-lite (분석 비상 폴백 전용) — 번역과 별도 모델·별도 한도.
-            # 보수적 기본값 RPM 10. 실제 한도는 AI Studio 콘솔 확인 후 조정.
-            "gemini_analysis": RateLimitInfo(
-                limit=10,
+            # 분석 폴백 Gemini 3.1 Flash-Lite: 3.5와 동일 한도.
+            "gemini_analysis_fb": RateLimitInfo(
+                limit=15,
                 window_seconds=60,
-                min_interval=6.0
+                min_interval=4.0
             ),
             # NVD API: API키 있으면 50req/30초
             "nvd": RateLimitInfo(
@@ -156,33 +164,33 @@ class RateLimitManager:
             "rate_limit_hits": 0
         }
 
-        # Groq 모델별 일일 한도 트래킹 — gpt-oss·qwen 각각 TPD 200K가 별도로 잡힌다.
-        # 요청 수(_gr_req)와 토큰 수(_tpd_used)를 모델별로 누적하고, 한도를 넘으면 소진으로
-        # 보고 다음 모델(캐스케이드)로 넘어간다. (rpd 기준도 지원하나 현 캐스케이드는 tpd만 사용.)
-        # (실행마다 상태 초기화 + 429 감지로 실제 일간 소진 반영.)
-        self._tpd_used_model: Dict[str, int] = {}   # 모델별 누적 토큰
-        self._gr_req_model: Dict[str, int] = {}     # 모델별 누적 요청 수
-        self._tpd_reset_model: Dict[str, datetime] = {}
-        self._tpd_exhausted_model: Dict[str, bool] = {}
-
-        # TPM (Tokens Per Minute) 선제 관리 — gpt-oss/qwen 모두 TPM 250K.
-        # 호출당 예약(~6K) « 250K라 사실상 발동 안 하는 안전장치.
+        # TPM(Tokens Per Minute) 선제 관리 — 번역만 등록한다. 콘솔 실측에서 병목이
+        # RPD(4%)나 RPM이 아니라 TPM(76%)이었기 때문이다. 넘기면 429를 맞고 30초씩
+        # 백오프하느니, 분 리셋까지 잠깐 기다리는 편이 싸다.
+        # 분석(flash-lite)은 TPM 250K에 호출이 하루 수십 건이라 등록할 이유가 없다.
         self._tpm_limits: Dict[str, int] = {
-            "groq": 250_000,  # gpt-oss-120b / qwen3.6 공통 TPM
+            "gemini": 16_000,     # Gemma 4 31B
+            "gemini_fb": 16_000,  # Gemma 4 26B
         }
         self._tpm_reserve: Dict[str, int] = {
-            "groq": 6_000,  # 호출당 예약 추정(입력 + max_completion 4096)
+            # 배치 1콜 추정: 6건 × (제목+500자 설명) 입력 + 최대 3,072 출력
+            "gemini": 4_000,
+            "gemini_fb": 4_000,
         }
         self._tpm_used: Dict[str, int] = {api: 0 for api in self._tpm_limits}
         self._tpm_reset_at: Dict[str, datetime] = {
             api: datetime.now() + timedelta(seconds=60) for api in self._tpm_limits
         }
 
-        # RPD (Requests Per Day) 트래킹 — Gemma 4 무료는 TPM이 무제한이라 일간 요청 수(1,500)가
-        # 실질적 일간 상한이다(토큰이 아님). 호출당 1건 누적, 90% 도달 시 경고.
+        # RPD (Requests Per Day) 트래킹. 호출당 1건 누적, 90% 도달 시 경고.
+        # AI Studio 콘솔 실측치. 예전에는 추정치를 넣어 두 값 모두 틀렸다 —
+        # 번역은 실제 14,400인데 1,500에서 끊고 있었고, 분석은 실제 500인데 1,000까지
+        # 허용해 한도 전에 막지 못했다.
         self._rpd_limits: Dict[str, int] = {
-            "gemini": 1_500,           # Gemma 4 (번역): RPD 1,500
-            "gemini_analysis": 1_000,  # flash-lite (분석 비상): 보수적 기본값 — 콘솔 확인 후 조정
+            "gemini": 14_400,             # Gemma 4 31B (번역)
+            "gemini_fb": 14_400,          # Gemma 4 26B (번역 폴백)
+            "gemini_analysis": 500,       # Gemini 3.5 Flash-Lite (분석)
+            "gemini_analysis_fb": 500,    # Gemini 3.1 Flash-Lite (분석 폴백)
         }
         self._rpd_used: Dict[str, int] = {api: 0 for api in self._rpd_limits}
         # RPD는 시간 단위 버킷의 롤링 24시간 합으로 센다. 이유는 두 가지다.
@@ -195,51 +203,7 @@ class RateLimitManager:
         self._rpd_buckets: Dict[str, Dict[str, int]] = {api: {} for api in self._rpd_limits}
         self._rpd_skip_warned: Dict[str, bool] = {}   # SKIP 경고 1회만 (로그 스팸 방지)
 
-        logger.info("Rate Limit Manager v3.5 초기화 완료 (Thread-Safe + 모델별 RPD/TPD 캐스케이드)")
-
-    @staticmethod
-    def _groq_model_limits(model: str) -> Dict[str, Optional[int]]:
-        """모델의 일일 한도 {rpd, tpd} 조회 (config). 미등록 시 TPD 200K 기본."""
-        try:
-            from config import config
-            return config.GROQ_MODEL_LIMITS.get(model, {"rpd": None, "tpd": 200_000})
-        except Exception:
-            return {"rpd": None, "tpd": 200_000}
-
-    def _ensure_groq_model(self, model: str) -> None:
-        """모델별 카운터 지연 초기화. 반드시 _lock 보유 상태에서 호출."""
-        if model not in self._tpd_used_model:
-            self._tpd_used_model[model] = 0
-            self._gr_req_model[model] = 0
-            self._tpd_reset_model[model] = datetime.now() + timedelta(hours=24)
-            self._tpd_exhausted_model[model] = False
-
-    def _groq_model_exhausted(self, model: str, required_tokens: int) -> bool:
-        """이 모델이 다음 호출을 감당 못 하는지 (rpd 또는 tpd 초과). _lock 보유 상태 가정."""
-        self._ensure_groq_model(model)
-        if datetime.now() >= self._tpd_reset_model[model]:  # 일간 리셋
-            self._tpd_used_model[model] = 0
-            self._gr_req_model[model] = 0
-            self._tpd_reset_model[model] = datetime.now() + timedelta(hours=24)
-            self._tpd_exhausted_model[model] = False
-        if self._tpd_exhausted_model[model]:
-            return True
-        lim = self._groq_model_limits(model)
-        rpd, tpd = lim.get("rpd"), lim.get("tpd")
-        if rpd is not None and self._gr_req_model[model] + 1 > rpd:
-            return True
-        if tpd is not None and self._tpd_used_model[model] + required_tokens > tpd:
-            return True
-        return False
-
-    def active_groq_model(self, models, required_tokens: int = 15000):
-        """우선순위 순 models 중 이번 호출을 감당할 여유(rpd·tpd)가 있는 첫 모델을 반환.
-        모두 소진이면 None. (앞 모델 소진 시 다음 모델로 전환하는 캐스케이드의 핵심.)"""
-        with self._lock:
-            for model in models:
-                if not self._groq_model_exhausted(model, required_tokens):
-                    return model
-            return None
+        logger.info("Rate Limit Manager 초기화 완료 (Thread-Safe · RPM/TPM/RPD 모델별 추적)")
 
     def check_and_wait(self, api_name: str, max_wait: Optional[float] = None) -> bool:
         """API 호출 전 반드시 호출. Lock으로 동시 접근 차단.
@@ -355,9 +319,8 @@ class RateLimitManager:
 
         return True
     
-    def record_call(self, api_name: str, tokens_used: int = 0, model: Optional[str] = None):
-        """API 호출 기록 (Thread-Safe). tokens_used가 있으면 TPM/TPD도 업데이트.
-        model이 주어지면(Groq) 해당 모델의 TPD 버킷에 누적한다."""
+    def record_call(self, api_name: str, tokens_used: int = 0):
+        """API 호출 기록 (Thread-Safe). tokens_used가 있으면 TPM도 업데이트."""
         if api_name not in self.limits:
             return
         with self._lock:
@@ -387,36 +350,6 @@ class RateLimitManager:
                     self._tpm_reset_at[api_name] = now + timedelta(seconds=60)
                 self._tpm_used[api_name] += tokens_used
 
-            # Groq 모델별 일일 사용량 (요청 수 + 토큰) — model이 주어진 Groq 호출만
-            if model:
-                self._ensure_groq_model(model)
-                now = datetime.now()
-                if now >= self._tpd_reset_model[model]:
-                    self._tpd_used_model[model] = 0
-                    self._gr_req_model[model] = 0
-                    self._tpd_reset_model[model] = now + timedelta(hours=24)
-                    self._tpd_exhausted_model[model] = False
-                    logger.info(f"🔄 {model} 일일 카운터 리셋")
-
-                self._gr_req_model[model] += 1
-                self._tpd_used_model[model] += tokens_used
-
-                lim = self._groq_model_limits(model)
-                rpd, tpd = lim.get("rpd"), lim.get("tpd")
-                if rpd:
-                    pct = self._gr_req_model[model] / rpd * 100
-                    if pct >= 90:
-                        logger.warning(f"⚠️ {model} RPD 90% 도달! ({self._gr_req_model[model]:,}/{rpd:,})")
-                if tpd:
-                    pct = self._tpd_used_model[model] / tpd * 100
-                    logger.debug(f"{model} TPD: {self._tpd_used_model[model]:,}/{tpd:,} ({pct:.1f}%)")
-                    if pct >= 90:
-                        logger.warning(f"⚠️ {model} TPD 90% 도달! ({self._tpd_used_model[model]:,}/{tpd:,})")
-
-    def is_tpd_exhausted(self, model: str, required_tokens: int = 15000) -> bool:
-        """특정 Groq 모델이 다음 호출을 감당 못 하는지(rpd 또는 tpd 소진) 확인."""
-        with self._lock:
-            return self._groq_model_exhausted(model, required_tokens)
 
     @staticmethod
     def _rpd_bucket_key(when: Optional[datetime] = None) -> str:
@@ -494,23 +427,13 @@ class RateLimitManager:
                 logger.warning(f"🚫 {api_name} 일일 한도(RPD) 소진 마킹 — SKIP 전환")
 
     def handle_429(self, api_name: str, retry_after: Optional[float] = None,
-                   error_message: str = "", model: Optional[str] = None):
-        """429 Too Many Requests 대응 (Thread-Safe). TPD 소진이면 대기 대신 즉시 마킹."""
+                   error_message: str = ""):
+        """429 Too Many Requests 대응 (Thread-Safe).
+
+        일일 한도(RPD) 소진 429는 대기해도 풀리지 않으므로 호출부가
+        mark_rpd_exhausted로 직접 마킹한다 — 여기서는 분당 한도만 다룬다."""
         with self._lock:
             self.stats["rate_limit_hits"] += 1
-
-            # 일일 한도(TPD 토큰 or RPD 요청) 소진 429 → 대기 무의미, 해당 모델 즉시 소진 마킹
-            _msg = error_message.lower()
-            if model and ("tokens per day" in _msg or "tpd" in _msg
-                          or "requests per day" in _msg or "rpd" in _msg or "per day" in _msg):
-                self._ensure_groq_model(model)
-                self._tpd_exhausted_model[model] = True
-                logger.warning(
-                    f"🚫 {model} 일일 한도 소진 429! 다음 모델/SKIP로 전환 "
-                    f"(누적 429: {self.stats['rate_limit_hits']}회)"
-                )
-                self.stats["total_waits"] += 1
-                return
 
             if api_name not in self.limits:
                 wait_time = retry_after if retry_after else 60
@@ -602,22 +525,7 @@ class RateLimitManager:
                     f"  {name:18s}: {info.used:4d}/{info.limit:4d} "
                     f"[{usage_bar}] {info.usage_percent:5.1f}%"
                 )
-        # Groq 모델별 일일 사용량 요약 (모델마다 RPD 또는 TPD 기준)
-        for model in self._tpd_used_model:
-            req = self._gr_req_model.get(model, 0)
-            tok = self._tpd_used_model.get(model, 0)
-            if req == 0 and not self._tpd_exhausted_model.get(model, False):
-                continue
-            lim = self._groq_model_limits(model)
-            rpd, tpd = lim.get("rpd"), lim.get("tpd")
-            exhausted = " (EXHAUSTED)" if self._tpd_exhausted_model.get(model, False) else ""
-            if rpd:  # RPD 기준 모델(현재 미사용 — tpd 기준만)
-                pct = req / rpd * 100
-                logger.info(f"  {(model[:14]+' RPD'):18s}: {req:,}/{rpd:,} [{self._create_usage_bar(pct)}] {pct:5.1f}%{exhausted}")
-            if tpd:  # 추론형: 토큰 기준
-                pct = tok / tpd * 100
-                logger.info(f"  {(model[:14]+' TPD'):18s}: {tok:,}/{tpd:,} [{self._create_usage_bar(pct)}] {pct:5.1f}%{exhausted}")
-        # RPD 요약 (Gemma 일간 요청 수)
+        # RPD 요약 (모델별 일간 요청 수)
         for api, limit in self._rpd_limits.items():
             used = self._rpd_used.get(api, 0)
             if used > 0:

--- a/src/rule_manager.py
+++ b/src/rule_manager.py
@@ -55,7 +55,7 @@ class RuleManager:
 
     def __init__(self):
         self.gh_token = os.environ.get("GH_TOKEN")
-        # AI 룰 생성 제거 — RuleManager는 공개 룰 검색 전용 (Groq 미사용)
+        # AI 룰 생성 제거 — RuleManager는 공개 룰 검색 전용 (AI 미사용)
         logger.info("✅ RuleManager 초기화 완료 (공개 룰 검색 전용: SigmaHQ / ET Open / Yara-Rules)")
 
     def _fetch_network_rules(self, cve_id: str) -> List[Dict[str, str]]:


### PR DESCRIPTION
콘솔 실측으로 한도를 다시 재고 나니, 유지하던 이중화가 실제로는 도달하지 않는
경로였다. 구조를 '공급자 2개'에서 '역할마다 모델 2단'으로 바꾼다.

모델:
- 분석  gemini-3.5-flash-lite → gemini-3.1-flash-lite → 정형 폴백
- 번역  gemma-4-31b-it        → gemma-4-26b-a4b-it    → 영문 원문
한도는 모델마다 따로 잡히므로 앞이 소진돼도 뒤는 멀쩡하다. 번역 폴백은 이번에
새로 붙였다 — 개별·배치 두 경로 모두.

Groq 제거 이유:
- 분석 대상이 Critical뿐이라 하루 6~30건인데 3.5의 RPD가 500이다. 비상 티어에 도달할 일이 없는데 캐스케이드·모델별 TPD 추적·reasoning 설정·Secret을 계속 들고 있었다(rate_limiter에서만 ~120줄).
- TPD 200K×2가 자주 바닥나 비상용으로도 신뢰할 수 없었다. 실제로 이걸 쓰는 날은 같은 성격의 CVE가 날마다 다른 모델에서 분석돼 리포트 기준이 흔들렸다.
- 최종 안전망은 어차피 정형 폴백이다. 공급자가 통째로 죽어도 리포트는 나가고 워터마크가 붙잡아 다음 실행에서 재처리된다 — 유실이 아니라 지연이다. 대가는 공급자 이중화 포기다. Google AI Studio가 멈춘 동안 분석란은 안내문으로, 번역은 영문으로 나가고 다음 실행의 백필이 회수한다.

한도 실측 반영 (둘 다 추정치가 틀려 있었다):
- 번역 RPD 1,500 → 14,400. 실제 병목은 RPD(4%)가 아니라 TPM(76%)이었다. 그래서 번역에만 TPM 16K 선제 관리를 건다 — 429를 맞고 30초씩 백오프하느니 분 리셋까지 잠깐 기다리는 편이 싸다.
- 분석 RPD 1,000 → 500. 실제보다 높게 잡아 한도 전에 막지 못하고 있었다.

넘김 규칙: 한도(rpd)·분당(rate)·서버오류(transient)는 다음 모델로, 안전 차단이나 형식 파손은 넘기지 않는다 — 같은 프롬프트로 결과가 같아 호출만 태운다.

함께 고친 것:
- 대시보드 전량 export 스위치(workflow_dispatch의 full_export). 백필은 확인일을 보존하려고 updated_at을 건드리지 않는데 증분 export는 그 컬럼으로 바뀐 행을 찾는다 — 손대지 않은 행이 옛 모습으로 남아 공개일이 채워져도 차트에 안 나왔다.
- 공개일 백필 종료 코드. 조회는 됐는데 겹치는 대상이 없는 경우(남은 게 창 밖의 오래된 CVE)까지 실패로 처리해 워크플로가 빨갛게 떴다. NVD 응답 자체가 없을 때만 1을 낸다.

검증: 스텁 캐스케이드 30항목 — 31B 성공 시 26B 미호출 / RPD 소진 시 인계·소진 마킹 / 안전차단은 미인계 / 503 3회 재시도 후 인계 / 2단 소진 시 영문·정형 폴백, 배치 경로 동일, 분석 3단계 동일. 백필 종료 코드 4경우. TPM 게이트 동작.
py_compile 전체 · 워크플로 YAML 파싱 · groq 문자열 잔재 0.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd