### PR TITLE
fix: SDK의 AFC 경로를 우회 — 쓰지도 않는 기능이 로그를 흐리고 있었다

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -92,7 +92,13 @@ class Analyzer:
                         safety_settings=[genai_types.SafetySetting(
                             category="HARM_CATEGORY_DANGEROUS_CONTENT",
                             threshold="BLOCK_NONE"
-                        )]
+                        )],
+                        # 우리는 tools를 주지 않으므로 함수 호출 자동 처리가 필요 없다.
+                        # 끄지 않으면 SDK가 AFC 루프로 들어가 "권장하지 않는다"는 경고를
+                        # 남긴다 — 동작은 같지만(도구가 없어 1회 호출 후 탈출) 로그만 흐려진다.
+                        automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
+                            disable=True
+                        ),
                     ),
                 )
                 rate_limit_manager.record_call(limiter_key)

--- a/src/main.py
+++ b/src/main.py
@@ -403,6 +403,11 @@ def _needs_cpe_lookup(cve_data: Dict) -> bool:
         for a in (cve_data.get('affected') or [])
     )
 
+# 우리는 tools를 주지 않으므로 함수 호출 자동 처리(AFC)가 필요 없다. 끄지 않으면
+# SDK가 AFC 루프로 들어가 "Models.generate_content에서 AFC 직접 사용은 권장하지
+# 않는다"는 경고를 남긴다 — 동작은 같지만(도구가 없어 1회 호출 후 탈출) 로그만 흐려진다.
+_NO_AFC = types.AutomaticFunctionCallingConfig(disable=True)
+
 # 번역 2단. 한도는 모델마다 따로 잡히므로 31B가 소진돼도 26B는 그대로 남아 있다 —
 # 앞 모델이 한도/서버 문제로 못 하면 뒤 모델이 이어받고, 둘 다 안 되면 영문 원문이다.
 _TRANSLATION_STAGES = (
@@ -472,7 +477,8 @@ def _translate_one(prompt: str, fallback: Tuple[str, str], model: str, limiter_k
                     safety_settings=[types.SafetySetting(
                         category="HARM_CATEGORY_DANGEROUS_CONTENT",
                         threshold="BLOCK_NONE"
-                    )]
+                    )],
+                    automatic_function_calling=_NO_AFC,
                 )
             )
             # Gemini 토큰 사용량 기록 (프리티어 잔여량 가시화)
@@ -706,7 +712,8 @@ def _translate_chunk_with(chunk: List[Dict], prompt: str, model: str, limiter_ke
                     safety_settings=[types.SafetySetting(
                         category="HARM_CATEGORY_DANGEROUS_CONTENT",
                         threshold="BLOCK_NONE"
-                    )]
+                    )],
+                    automatic_function_calling=_NO_AFC,
                 )
             )
             tokens = 0


### PR DESCRIPTION
실행 로그에 "Direct use of automatic function calling (AFC) in Models.generate_content is not recommended"가 찍혔다. 동작 문제는 아니다 — google-genai는 config에 automatic_function_calling이 없으면 AFC를 기본 활성으로 보고 루프에 들어가는데, 우리는 tools를 주지 않으므로 function_map이 비어 첫 호출 직후 break 한다(models.py:6604). 호출 수·토큰·응답 모두 동일하다.

다만 우리가 절대 쓰지 않는 기능 때문에 프로세스마다 경고가 한 번씩 남는 건
로그를 읽을 때 방해가 된다. 세 호출부(개별 번역·배치 번역·심층 분석) 모두
disable=True를 명시해 SDK가 AFC 래퍼를 건너뛰고 바로 _generate_content로 가게 한다.

검증: 파이프라인이 실제로 만드는 config 그대로 should_disable_afc가 True를 반환하는지(번역·분석 양쪽) · 부수 경고 0 · 캐스케이드 30항목 회귀 없음.


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd