### PR TITLE
refactor: 대시보드 커널 접기 제거 — 페이지 단위라 숫자가 사실이 아니었다

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -256,11 +256,6 @@ tr[data-severity="None"] td.cell-sev::before { background: var(--sev-none); }
 /* 내 SBOM과 일치한 행 — 목록에서 즉시 눈에 띄게 */
 
 /* Linux 커널 접이식 그룹 — 목록의 절반을 차지하는 커널 CVE를 한 줄로 묶는다 */
-.kernel-fold td { background: color-mix(in srgb, var(--surface-2) 80%, transparent); font-weight: 600; color: var(--text); cursor: pointer; }
-.kernel-fold:hover td { background: var(--surface-2); }
-.kernel-fold .fold-caret { display: inline-block; margin-right: 8px; color: var(--text-muted); }
-.kernel-fold .fold-count { margin-left: 8px; font-weight: 500; color: var(--text-muted); }
-.kernel-fold .fold-meta { float: right; font-weight: 500; font-size: 12px; color: var(--text-faint); }
 
 /* SBOM에서 그대로 찾을 수 있는 패키지 이름 — 제품명만으로는 대조가 안 된다 */
 .pkg-keys { display: inline-flex; gap: 4px; margin-left: 6px; flex-wrap: wrap; }

--- a/docs/cve.html
+++ b/docs/cve.html
@@ -99,7 +99,7 @@
           <button class="seg-btn signal" data-signal="auto" title="CISA SSVC Automatable=yes — 점수가 낮아도 대량 자동 공격 대상">🤖 자동화 가능</button>
           <button class="seg-btn signal" data-signal="patched" title="OSV가 수정 버전을 알려주는 건 — 올릴 목표가 있는 것부터 처리할 때">🩹 패치 있음</button>
         </div>
-        <select class="filter-select" id="kernel-filter" title="Linux 커널 CVE는 전부 Linux/Linux로만 표기돼 제품 구분이 없습니다">
+        <select class="filter-select" id="kernel-filter" title="Linux 커널 CVE는 전부 Linux/Linux로만 표기돼 제품 구분이 없습니다. 커널은 CVE마다 고치는 게 아니라 패키지를 한 번 올리는 단위라, 나머지를 훑을 땐 제외하고 보는 편이 낫습니다.">
           <option value="">커널 포함</option>
           <option value="hide">커널 제외</option>
           <option value="only">커널만</option>

--- a/docs/js/cve-dashboard.js
+++ b/docs/js/cve-dashboard.js
@@ -16,7 +16,6 @@ let activeFilters = {
   search: '', vendor: '', product: '', month: '', day: '',
   kernel: '',           // '' 전체 | 'only' 커널만 | 'hide' 커널 제외
 };
-let kernelExpanded = false;   // 목록에서 커널 그룹을 펼쳤는지
 
 const SEV_VAR = { Critical: '--sev-critical', High: '--sev-high', Medium: '--sev-medium', Low: '--sev-low', None: '--sev-none' };
 const sevColor = s => `var(${SEV_VAR[s] || '--sev-none'})`;
@@ -40,6 +39,7 @@ async function init() {
     buildProductFilter();
     buildMonthFilter();
     buildDayFilter();
+    labelKernelFilter();
     applyFilters();
   } catch (e) {
     console.error('Data load failed:', e);
@@ -197,6 +197,23 @@ function buildAffectedFilter(key, selectId, limit = 40) {
 const buildVendorFilter = () => buildAffectedFilter('vendor', 'vendor-filter');
 const buildProductFilter = () => buildAffectedFilter('product', 'product-filter');
 
+/** 커널 필터 라벨에 실제 전체 건수를 넣는다.
+ *  예전 접기 머리글은 '이 페이지에 있는 커널 수'를 보여줘서, 같은 목록을 넘길 때마다
+ *  숫자가 달라지고 전체 규모는 끝내 알 수 없었다. 여기서 한 번만 말하면 정확하다. */
+function labelKernelFilter() {
+  const select = document.getElementById('kernel-filter');
+  if (!select) return;
+  const n = statsData.cve?.kernel_count ?? allCves.filter(c => c.is_kernel).length;
+  if (!n) return;
+  const total = allCves.length;
+  const opts = {
+    '': `커널 포함 (전체 ${total.toLocaleString()}건)`,
+    'hide': `커널 제외 (${n.toLocaleString()}건 숨김)`,
+    'only': `커널만 (${n.toLocaleString()}건)`,
+  };
+  [...select.options].forEach(o => { if (opts[o.value]) o.textContent = opts[o.value]; });
+}
+
 const cveMonth = cve => (cve.date || '').slice(0, 7);
 const cveDay = cve => (cve.date || '').slice(0, 10);
 
@@ -331,34 +348,12 @@ function renderTable() {
     return;
   }
 
-  // 커널 CVE는 접이식 한 줄로 묶는다 — 전부 Linux/Linux라 제품 단위 구분이 없고
-  // 목록의 절반을 차지해 나머지를 덮어버린다. 숨기는 게 아니라 접는 것이다.
-  const kernels = page.filter(c => c.is_kernel);
-  const rest = page.filter(c => !c.is_kernel);
-  const showKernel = kernelExpanded || !kernels.length;
-  const ordered = showKernel ? page : rest;
-
-  let head = '';
-  if (kernels.length && !kernelExpanded) {
-    const crit = kernels.filter(c => c.severity === 'Critical').length;
-    const high = kernels.filter(c => c.severity === 'High').length;
-    head = `<tr class="kernel-fold" onclick="toggleKernel()" title="클릭하면 펼칩니다">
-      <td colspan="8"><span class="fold-caret">&#9656;</span>&#128039; Linux 커널
-        <span class="fold-count">${kernels.length.toLocaleString()}건</span>
-        <span class="fold-meta">Critical ${crit} · High ${high} · 이 페이지에서 접힘</span></td></tr>`;
-  } else if (kernels.length) {
-    head = `<tr class="kernel-fold expanded" onclick="toggleKernel()" title="클릭하면 접습니다">
-      <td colspan="8"><span class="fold-caret">&#9662;</span>&#128039; Linux 커널
-        <span class="fold-count">${kernels.length.toLocaleString()}건</span>
-        <span class="fold-meta">펼쳐짐</span></td></tr>`;
-  }
-
-  if (!ordered.length && !head) {
-    tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="icon">&#128269;</div><p>조건에 맞는 CVE가 없습니다.</p></td></tr>';
-    return;
-  }
-
-  tbody.innerHTML = head + ordered.map(cve => {
+  // 커널 접기는 없앴다. 페이지를 자른 뒤에 접다 보니 머리글의 'Critical N · High M'이
+  // 전체가 아니라 그 50행 안의 수였고, 커널만 들어찬 페이지에서는 데이터 행이 0개인
+  // 빈 화면이 나왔다(실측 241페이지 중 79페이지). 페이지 표시는 '총 12,005건'이라고
+  // 하는데 실제로 보이는 건 0~50행으로 제각각이라 개수를 신뢰할 수 없었다.
+  // 커널을 넣고 빼고 보는 세 가지는 위의 커널 필터가 이미 정확하게 해준다.
+  tbody.innerHTML = page.map(cve => {
     const sev = cve.severity || 'None';
     const vendor = cve.affected?.[0]?.vendor || '-';
     const product = cve.affected?.[0]?.product || '';
@@ -382,11 +377,6 @@ function renderTable() {
       <td class="date-cell">${dateStr}</td>
     </tr>`;
   }).join('');
-}
-
-function toggleKernel() {
-  kernelExpanded = !kernelExpanded;
-  renderTable();
 }
 
 function signalBadges(cve) {
@@ -717,7 +707,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('day-filter')?.addEventListener('change', e => { activeFilters.day = e.target.value; applyFilters(); });
   document.getElementById('kernel-filter')?.addEventListener('change', e => {
     activeFilters.kernel = e.target.value;
-    kernelExpanded = e.target.value === 'only';   // 커널만 볼 땐 접을 이유가 없다
     applyFilters();
   });
 


### PR DESCRIPTION
지적이 맞았다. 접기가 페이지를 자른 **뒤에** 동작해서, 머리글의 'Critical N · High M'은 전체가 아니라 그 50행 안의 수였다. 그리고 실제로는 더 나빴다.

실측(배포 데이터 12,005행 · 커널 4,879행 41%):
  · 241페이지 중 **79페이지가 데이터 행 0개** — 접기 머리글 한 줄만 있는 빈 화면.
    커널이 그 페이지를 다 채운 구간에서 '다음'을 누르면 아무것도 없는 화면이 나온다.
  · 92페이지가 10행 이하.
  · 페이지 정보는 '총 12,005건'이라고 하는데 실제로 보이는 건 0~50행으로 제각각이라
    개수를 신뢰할 수 없었다.
  · 머리글이 말하는 커널 수는 페이지마다 14 → 0 → 26 → 50으로 바뀌는데, 진짜 전체는
    4,879건(Critical 545 · High 4,334)이다. 끝내 알 수 없는 숫자였다.

게다가 커널을 넣고/빼고/만 보는 세 경우는 위의 커널 필터가 이미 정확하게 해준다.
접기는 그 위에 얹힌 두 번째 축이었고, 상태(kernelExpanded)가 전역이라 한 페이지에서 펼치면 다른 페이지까지 따라 바뀌었다.

→ 접기를 걷어내고, 그 자리에 **진짜 전체 건수**를 필터 라벨에 넣는다.
   '커널 포함 (전체 12,005건)' · '커널 제외 (4,879건 숨김)' · '커널만 (4,879건)'
   stats의 kernel_count는 이미 만들어 두고 화면에서 안 쓰고 있었다.

터미널 도구(tools/sbom_match.py)의 [묶음]은 그대로 둔다 — 그쪽은 전체 결과를 패키지 단위로 접으므로 표시되는 건수가 실제 총계다(페이지 개념이 없다).

검증: 브라우저 13항목 — 접기 행 부재, 예전에 0행이던 10·11·12페이지가 정확히 50행, 페이지 정보와 실제 행수 일치, 커널 필터 세 경우가 12,005/7,126/4,879로 정확, 라벨이 페이지 단위가 아닌 총계 표시, 모달·필터·CSV 회귀 없음, 콘솔 오류 0. 기존 스위트 108항목 회귀 없음. 고아 CSS 0(113개 전수 대조).


Claude-Session: https://claude.ai/code/session_01Qtv26mfVXUhSSSg6GJ5hbd